### PR TITLE
revert: fix(github-release): update dragonflydb/dragonfly-operator ( operator/v1.1.2/manifests/crd.yaml → v1.1.3 )

### DIFF
--- a/cluster/apps/database/dragonfly/app/kustomization.yaml
+++ b/cluster/apps/database/dragonfly/app/kustomization.yaml
@@ -4,6 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # renovate: datasource=github-releases repos=dragonflydb/dragonfly-operator
-  - https://raw.githubusercontent.com/dragonflydb/dragonfly-v1.1.3
+  - https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/v1.1.2/manifests/crd.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml


### PR DESCRIPTION
Reverts Diaoul/home-ops#5649