### PR TITLE
revert: "feat(container): update ghcr.io/siderolabs/kubelet ( v1.30.3 → v1.31.0 )"

### DIFF
--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/ks.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/ks.yaml
@@ -51,4 +51,4 @@ spec:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
       TALOS_VERSION: v1.7.6
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-      KUBERNETES_VERSION: v1.31.0
+      KUBERNETES_VERSION: v1.30.3

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.7.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.31.0
+kubernetesVersion: v1.30.3
 
 clusterName: home-kubernetes
 endpoint: https://10.0.3.3:6443


### PR DESCRIPTION
Reverts Diaoul/home-ops#5894

Not supported by Talos 1.7.6 yet