### PR TITLE
feat(actions-runner): align runner with onedr0p/home-ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,5 +411,8 @@ Flux is configured with a GitHub webhook — reconciliation triggers immediately
 - Do not create a new `OCIRepository` for app-template — use the shared one in `components/common/`
 - Do not skip `# yaml-language-server: $schema=...` headers on YAML files
 - Do not use `latest` tags for any container image
-- Do not use `NetworkPolicy` or `CiliumNetworkPolicy` — cluster does not use them
+- Do not use `NetworkPolicy` or `CiliumNetworkPolicy` — the cluster does not use them.
+  One deliberate exception: `actions-runner-system/.../runners/home-ops/networkpolicy.yaml`
+  fences the GitHub Actions runner off the LAN, mirroring onedr0p/home-ops.
+  Do not delete it as drift, and do not read it as licence to add more.
 - Do not suffix Secret names with `-secret` — use the app name directly (e.g. `name: myapp` not `name: myapp-secret`)

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     githubConfigUrl: https://github.com/Diaoul/home-ops
     githubConfigSecret: home-ops-runner-secret
-    minRunners: 1
+    minRunners: 0
     maxRunners: 3
     containerMode:
       type: kubernetes
@@ -27,7 +27,17 @@ spec:
       name: actions-runner-controller
       namespace: actions-runner-system
     template:
+      metadata:
+        labels:
+          runner: *name
       spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    runner: *name
+                topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.336.0@sha256:281a9a090522fafbf4967f158b8c97d03552b1978b688893c5f7cb1944bc5fe5

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./networkpolicy.yaml
   - ./ocirepository.yaml
   - ./rbac.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/networkpolicy.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/networkpolicy.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
+# Fences the GitHub Actions runner off the LAN. It is the only network policy in
+# the cluster; see the exception noted in CLAUDE.md.
+#
+# Structure follows onedr0p/home-ops, but every CIDR here is site-specific and
+# does not transfer: upstream's nodes are 192.168.42.0/24 and its policy denies
+# 10.0.0.0/8, which would break talosctl against this cluster's 10.0.3.x nodes.
+#
+# enableDefaultDeny.egress stays false so the endpoint is not flipped to
+# default-deny -- these are deny rules layered on otherwise-open egress. Internet
+# egress is deliberately preserved: mise fetches talosctl and images come from
+# ghcr.io.
+#
+# Known gap: the container hook labels the workload pods it creates with only
+# runner-pod-name, so a job declaring container: or services: would get an
+# unfenced pod. No job does today. Widen endpointSelector to {} (all pods in the
+# namespace) if that changes -- the controller and listener only need the
+# kube-apiserver and GitHub, so fencing them costs nothing.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: &name home-ops-runner
+spec:
+  endpointSelector:
+    matchLabels:
+      runner: *name
+  enableDefaultDeny:
+    egress: false
+  egressDeny:
+    - toCIDRSet:
+        # Tighter than the 10.0.3.0/24 SERVER VLAN on purpose: the NAS shares that
+        # VLAN and stays out of reach. A node outside 10.0.3.24-31 makes the Image
+        # Pull workflow hang rather than fail usefully -- see talos/README.md.
+        - cidr: 10.0.0.0/8
+          except:
+            - 10.42.0.0/16 # pods
+            - 10.43.0.0/16 # services
+            - 10.0.3.24/29 # k8s-node-1..5, for talosctl image pull
+    - toCIDR:
+        - 172.16.0.0/12
+        - 192.168.0.0/16

--- a/talos/README.md
+++ b/talos/README.md
@@ -35,6 +35,19 @@ under `data:` in `topf.yaml` and are reachable as `.Data.<key>`.
 | `rendered/` | no | plaintext machine configs, `just talos render` |
 | `images/` | no | downloaded installer ISOs |
 
+## Adding or renumbering a node
+
+Node IPs are hardcoded in one place outside `talos/`: the GitHub Actions runner's
+CiliumNetworkPolicy at
+`kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/networkpolicy.yaml`
+excepts `10.0.3.24/29` (`10.0.3.24`–`10.0.3.31`) so the runner can reach the Talos
+API for `talosctl image pull`. The range is tighter than the `10.0.3.0/24` SERVER
+VLAN on purpose — the NAS shares that VLAN and is intentionally out of reach.
+
+A node outside `.24`–`.31` makes the `Image Pull` workflow hang and time out
+against that node rather than fail with a useful error. Widen the `except` entry
+when you add one.
+
 ## Upgrades
 
 Talos version upgrades are driven **in-cluster by tuppr** (`TalosUpgrade` in


### PR DESCRIPTION
Closes the three gaps between this repo's runner config and upstream's. All are things this repo never picked up rather than deliberate divergences.

Replaces #8420, which went the other way — it diverged from upstream on `rbac.yaml` (where this repo already matched) while leaving the actual gap open. That framing was backwards, and its threat model is gone now that fork PR approval is set to `all_external_contributors`.

## CiliumNetworkPolicy

Fences the runner off the LAN. Structure follows upstream, but **every CIDR is rewritten** — upstream's nodes are `192.168.42.0/24` and its policy denies `10.0.0.0/8`, which would cut this cluster's `10.0.3.x` nodes off from `talosctl` entirely.

Node range is excepted as `10.0.3.24/29` (`.24`–`.31`) rather than the full `10.0.3.0/24` SERVER VLAN, so the NAS sharing that VLAN stays unreachable. `enableDefaultDeny.egress` stays `false`, so these are deny rules layered on open egress rather than a flip to default-deny — internet access for mise and ghcr.io is preserved.

Known gap, noted in-file: the container hook labels workload pods with only `runner-pod-name` ([`packages/k8s/src/k8s/index.ts:92`](https://github.com/actions/runner-container-hooks/blob/main/packages/k8s/src/k8s/index.ts#L92)), so a job declaring `container:` or `services:` would get an unfenced pod. No job does today. Widening `endpointSelector` to `{}` closes it if that changes.

## minRunners 1 → 0

An idle runner pod and its 10Gi `ceph-block` volume were held permanently for a workflow that fires a few times a day. Costs a cold start per run.

## podAntiAffinity

Spreads concurrent runners across nodes, `maxRunners: 3` over 5 nodes. Needs the `runner` label upstream sets via `template.metadata.labels`, which the policy selector also uses — so both changes land together.

## Notes

This is the cluster's only network policy, so the exception is recorded in `CLAUDE.md` rather than left looking like drift, and the node CIDR coupling is documented in `talos/README.md` (a node outside `.24`–`.31` makes `Image Pull` hang rather than fail usefully).

**Unverified:** `egressDeny` with `enableDefaultDeny.egress: false` has never been exercised on this cluster — no CNP has ever been applied here. The shape matches upstream and validates against the schema, but that is not proof the deny takes effect. Worth one curl to a LAN IP from a runner pod after merge; an inert fence believed to work is worse than none.

`scripts/kubeconform.sh` and `yamllint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)