### PR TITLE
feat(scripts): sort manifest keys with yamlsorter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ talosconfig
 /talos/output/
 # Misc.
 .venv/
+__pycache__/
+.pytest_cache/

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -1,7 +1,23 @@
+# Sequential: sort-manifests rewrites key order, so yamlfmt has to run after it to
+# normalise the result. lefthook only honours `priority` when commands do not run
+# in parallel.
 [pre-commit]
-parallel = true
+parallel = false
+
+[pre-commit.commands.sort-manifests]
+priority = 1
+run = "python scripts/yamlsorter/yamlsorter.py {staged_files}"
+glob = ["**/helmrelease.yaml", "**/kustomization.yaml", "**/ks.yaml"]
+stage_fixed = true
+
+[pre-commit.commands.format-yaml]
+priority = 2
+run = "yamlfmt {staged_files}"
+glob = ["*.yaml", "!*.sops.yaml"]
+stage_fixed = true
 
 [pre-commit.commands.format-just]
+priority = 3
 run = """
 for file in {staged_files}; do
     just --justfile "$file" --fmt
@@ -9,9 +25,3 @@ done
 """
 glob = ["*.just", ".justfile"]
 stage_fixed = true
-
-[pre-commit.commands.format-yaml]
-run = "yamlfmt {staged_files}"
-glob = ["*.yaml", "!*.sops.yaml"]
-stage_fixed = true
-

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -5,9 +5,9 @@ kind: HelmRelease
 metadata:
   name: &name actions-runner-controller
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: gha-runner-scale-set-controller
-  interval: 1h
   values:
     fullnameOverride: *name

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: actions-runner-controller
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
+  interval: 1h
   targetNamespace: actions-runner-system
+  prune: true
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,16 +21,16 @@ kind: Kustomization
 metadata:
   name: actions-runner-controller-runners
 spec:
-  dependsOn:
-    - name: actions-runner-controller
-    - name: miroir-config
-      namespace: miroir-system
-  interval: 1h
-  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
+  interval: 1h
+  dependsOn:
+    - name: actions-runner-controller
+    - name: miroir-config
+      namespace: miroir-system
   targetNamespace: actions-runner-system
+  prune: true
   wait: false

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: &name home-ops-runner
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: gha-runner-scale-set
-  interval: 1h
   values:
     githubConfigUrl: https://github.com/Diaoul/home-ops
     githubConfigSecret: home-ops-runner-secret

--- a/kubernetes/apps/ai/context7-mcp/ks.yaml
+++ b/kubernetes/apps/ai/context7-mcp/ks.yaml
@@ -5,20 +5,20 @@ kind: Kustomization
 metadata:
   name: context7-mcp
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: context7-mcp
-  path: ./kubernetes/apps/ai/context7-mcp/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/ai/context7-mcp/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: litellm
       namespace: ai
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: context7-mcp
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: ai

--- a/kubernetes/apps/ai/ha-mcp/ks.yaml
+++ b/kubernetes/apps/ai/ha-mcp/ks.yaml
@@ -5,24 +5,24 @@ kind: Kustomization
 metadata:
   name: ha-mcp
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: ha-mcp
-  path: ./kubernetes/apps/ai/ha-mcp/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/ai/ha-mcp/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: litellm
       namespace: ai
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: ha-mcp
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: ai
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/ai/litellm-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: litellm-operator
 spec:
+  interval: 30m
   chartRef:
     kind: OCIRepository
     name: litellm-operator
-  interval: 30m
   values:
     controller:
       leaderElection:

--- a/kubernetes/apps/ai/litellm-operator/ks.yaml
+++ b/kubernetes/apps/ai/litellm-operator/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: litellm-operator
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: litellm-operator
-  path: ./kubernetes/apps/ai/litellm-operator/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/ai/litellm-operator/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     # autoRegister is checked at operator startup, so the CRD must exist first
     - name: llmkube
       namespace: ai
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: litellm-operator
   prune: true
   wait: true
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: ai

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -5,35 +5,35 @@ kind: Kustomization
 metadata:
   name: litellm
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: litellm
-  path: ./kubernetes/apps/ai/litellm/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  components:
-    - ../../../../components/dragonfly
-  healthCheckExprs:
-    - apiVersion: dragonflydb.io/v1alpha1
-      kind: Dragonfly
-      failed: status.phase != 'ready'
-      current: status.phase == 'ready'
+  path: ./kubernetes/apps/ai/litellm/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: litellm-operator
       namespace: ai
     - name: dragonfly-operator
       namespace: database
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: litellm
+  components:
+    - ../../../../components/dragonfly
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: litellm
-  targetNamespace: ai
+  prune: true
+  wait: false
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      current: status.phase == 'ready'
+      failed: status.phase != 'ready'

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: llmkube
 spec:
+  interval: 30m
   chartRef:
     kind: OCIRepository
     name: llmkube
-  interval: 30m
   values:
     namespace: ai
     crds:

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -5,25 +5,25 @@ kind: Kustomization
 metadata:
   name: llmkube
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: llmkube
-  path: ./kubernetes/apps/ai/llmkube/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/ai/llmkube/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube
+  prune: true
+  wait: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: llmkube
       namespace: ai
-  prune: true
-  wait: true
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: ai
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -31,14 +31,14 @@ kind: Kustomization
 metadata:
   name: llmkube-models
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: llmkube-models
-  path: ./kubernetes/apps/ai/llmkube/models
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/ai/llmkube/models
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: llmkube
       namespace: ai
@@ -46,14 +46,14 @@ spec:
       namespace: kube-system
     - name: miroir-config
       namespace: miroir-system
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube-models
+  prune: true
+  wait: true
   healthCheckExprs:
     - apiVersion: inference.llmkube.dev/v1alpha1
       kind: InferenceService
-      failed: status.phase == 'Failed'
       current: status.phase == 'Ready'
-  prune: true
-  wait: true
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: ai
+      failed: status.phase == 'Failed'

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: memini
 spec:
+  interval: 30m
   chartRef:
     kind: OCIRepository
     name: memini
-  interval: 30m
   values:
     controllers:
       main:

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -5,16 +5,14 @@ kind: Kustomization
 metadata:
   name: memini
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: memini
-  path: ./kubernetes/apps/ai/memini/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  components:
-    - ../../../../components/persistence
+  path: ./kubernetes/apps/ai/memini/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: litellm
       namespace: ai
@@ -24,16 +22,18 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: memini
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: memini
       CAPACITY: 5Gi
-  targetNamespace: ai
+  prune: true
+  wait: false

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       open-webui:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -70,6 +63,13 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 2Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -77,11 +77,11 @@ spec:
             port: 8080
     route:
       app:
-        hostnames:
-          - chat.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - chat.${DOMAIN}
     persistence:
       config:
         existingClaim: open-webui

--- a/kubernetes/apps/ai/open-webui/ks.yaml
+++ b/kubernetes/apps/ai/open-webui/ks.yaml
@@ -5,22 +5,14 @@ kind: Kustomization
 metadata:
   name: open-webui
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: open-webui
-  path: ./kubernetes/apps/ai/open-webui/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  components:
-    - ../../../../components/persistence
-    - ../../../../components/dragonfly
-  healthCheckExprs:
-    - apiVersion: dragonflydb.io/v1alpha1
-      kind: Dragonfly
-      failed: status.phase != 'ready'
-      current: status.phase == 'ready'
+  path: ./kubernetes/apps/ai/open-webui/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: litellm
       namespace: ai
@@ -30,16 +22,24 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: open-webui
+  components:
+    - ../../../../components/persistence
+    - ../../../../components/dragonfly
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: open-webui
       CAPACITY: 5Gi
-  targetNamespace: ai
+  prune: true
+  wait: false
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      current: status.phase == 'ready'
+      failed: status.phase != 'ready'

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -5,6 +5,20 @@ kind: Kustomization
 metadata:
   name: cert-manager
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/cert-manager/cert-manager/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
+  targetNamespace: cert-manager
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -16,19 +30,5 @@ spec:
   healthCheckExprs:
     - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
-      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
-  interval: 1h
-  path: ./kubernetes/apps/cert-manager/cert-manager/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  timeout: 5m
-  targetNamespace: cert-manager
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: cloudnative-pg
 spec:
-  path: ./kubernetes/apps/database/cloudnative-pg/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/database/cloudnative-pg/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: database
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: database
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -27,26 +27,26 @@ kind: Kustomization
 metadata:
   name: cloudnative-pg-barman-cloud
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/database/cloudnative-pg/barman-cloud
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: cert-manager
       namespace: cert-manager
     - name: cloudnative-pg
       namespace: database
-  path: ./kubernetes/apps/database/cloudnative-pg/barman-cloud
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: true
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: database
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: database
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -54,11 +54,14 @@ kind: Kustomization
 metadata:
   name: cloudnative-pg-cluster
 spec:
-  path: ./kubernetes/apps/database/cloudnative-pg/cluster
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/database/cloudnative-pg/cluster
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: cloudnative-pg
       namespace: database
@@ -66,13 +69,10 @@ spec:
       namespace: database
     - name: miroir-config
       namespace: miroir-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: database
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: database
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: dragonfly-operator
 spec:
+  interval: 30m
   chartRef:
     kind: OCIRepository
     name: dragonfly-operator
-  interval: 30m
   values:
     controllers:
       dragonfly-operator:

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: dragonfly-operator
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/database/dragonfly/app
+  interval: 1h
+  timeout: 5m
+  targetNamespace: database
   commonMetadata:
     labels:
       app.kubernetes.io/name: dragonfly-operator
+  prune: true
+  wait: false
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: dragonfly-operator
       namespace: database
-  interval: 1h
-  path: ./kubernetes/apps/database/dragonfly/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: database
-  timeout: 5m
-  wait: false

--- a/kubernetes/apps/database/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/database/mosquitto/app/helmrelease.yaml
@@ -5,11 +5,18 @@ kind: HelmRelease
 metadata:
   name: mosquitto
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
-  interval: 1h
   values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
     controllers:
       mosquitto:
         containers:
@@ -26,13 +33,6 @@ spec:
                 cpu: 10m
               limits:
                 memory: 100Mi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         type: LoadBalancer
@@ -41,10 +41,10 @@ spec:
           gatus.home-operations.com/endpoint: |-
             group: services
           lbipam.cilium.io/ips: 10.44.0.16
-        externalTrafficPolicy: Local
         ports:
           mqtt:
             port: 1883
+        externalTrafficPolicy: Local
     configMaps:
       config:
         data:
@@ -61,7 +61,7 @@ spec:
         existingClaim: mosquitto
       config-file:
         type: configMap
-        identifier: config
         globalMounts:
           - path: /mosquitto/config/mosquitto.conf
             subPath: mosquitto.conf
+        identifier: config

--- a/kubernetes/apps/database/mosquitto/ks.yaml
+++ b/kubernetes/apps/database/mosquitto/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: mosquitto
 spec:
-  path: ./kubernetes/apps/database/mosquitto/app
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/database/mosquitto/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  targetNamespace: database
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: database
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       mealie:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -55,6 +48,13 @@ spec:
                 memory: 400Mi
               limits:
                 memory: 600Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -62,11 +62,11 @@ spec:
             port: 9000
     route:
       app:
-        hostnames:
-          - mealie.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - mealie.${DOMAIN}
     persistence:
       config:
         existingClaim: mealie

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -5,28 +5,28 @@ kind: Kustomization
 metadata:
   name: mealie
 spec:
-  components:
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/default/mealie/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/default/mealie/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: default
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: mealie
       CAPACITY: 100Mi
-  targetNamespace: default
+  prune: true
+  wait: false

--- a/kubernetes/apps/default/miniflux/app/helmrelease.yaml
+++ b/kubernetes/apps/default/miniflux/app/helmrelease.yaml
@@ -14,11 +14,6 @@ spec:
       miniflux:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
         initContainers:
           init-db:
             image:
@@ -71,11 +66,23 @@ spec:
                 cpu: 10m
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
     service:
       app:
         ports:
           http:
             port: *port
+    route:
+      app:
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+        hostnames:
+          - miniflux.${DOMAIN}
     serviceMonitor:
       app:
         serviceName: miniflux
@@ -85,10 +92,3 @@ spec:
             path: /metrics
             interval: 1m
             scrapeTimeout: 10s
-    route:
-      app:
-        hostnames:
-          - miniflux.${DOMAIN}
-        parentRefs:
-          - name: envoy-external
-            namespace: network

--- a/kubernetes/apps/default/miniflux/ks.yaml
+++ b/kubernetes/apps/default/miniflux/ks.yaml
@@ -5,23 +5,23 @@ kind: Kustomization
 metadata:
   name: miniflux
 spec:
-  path: ./kubernetes/apps/default/miniflux/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/default/miniflux/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: cloudnative-pg-cluster
       namespace: database
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: default
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: miniflux
-  targetNamespace: default
+  prune: true
+  wait: false

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       searxng:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 977
-            runAsGroup: 977
-            fsGroup: 977
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -64,6 +57,13 @@ spec:
                 memory: 215Mi
               limits:
                 memory: 4Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 977
+            runAsGroup: 977
+            fsGroup: 977
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -71,11 +71,11 @@ spec:
             port: *httpPort
     route:
       app:
-        hostnames:
-          - search.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - search.${DOMAIN}
     persistence:
       config:
         type: configMap

--- a/kubernetes/apps/default/searxng/ks.yaml
+++ b/kubernetes/apps/default/searxng/ks.yaml
@@ -5,33 +5,33 @@ kind: Kustomization
 metadata:
   name: searxng
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: searxng
-  path: ./kubernetes/apps/default/searxng/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  components:
-    - ../../../../components/dragonfly
-  healthCheckExprs:
-    - apiVersion: dragonflydb.io/v1alpha1
-      kind: Dragonfly
-      failed: status.phase != 'ready'
-      current: status.phase == 'ready'
+  path: ./kubernetes/apps/default/searxng/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: dragonfly-operator
       namespace: database
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: searxng
+  components:
+    - ../../../../components/dragonfly
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: searxng
-  targetNamespace: default
+  prune: true
+  wait: false
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      current: status.phase == 'ready'
+      failed: status.phase != 'ready'

--- a/kubernetes/apps/default/thelounge/app/helmrelease.yaml
+++ b/kubernetes/apps/default/thelounge/app/helmrelease.yaml
@@ -5,22 +5,15 @@ kind: HelmRelease
 metadata:
   name: thelounge
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
-  interval: 1h
   values:
     controllers:
       thelounge:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -28,20 +21,27 @@ spec:
               tag: 4.5.2@sha256:8aded5dfd825eb619d268292563c87f8ecd74c4e83a4f48cbcad82ffc6103466
             env:
               THELOUNGE_HOME: /config/thelounge
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness:
                 enabled: true
               readiness:
                 enabled: true
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -49,11 +49,11 @@ spec:
             port: 9000
     route:
       app:
-        hostnames:
-          - thelounge.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - thelounge.${DOMAIN}
     persistence:
       config:
         existingClaim: thelounge

--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -5,28 +5,28 @@ kind: Kustomization
 metadata:
   name: thelounge
 spec:
-  components:
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/default/thelounge/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  path: ./kubernetes/apps/default/thelounge/app
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 2m
-  timeout: 5m
+  targetNamespace: default
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: thelounge
       CAPACITY: 5Gi
-  targetNamespace: default
+  prune: true
+  wait: false

--- a/kubernetes/apps/default/vaultwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/default/vaultwarden/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       vaultwarden:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -48,6 +41,13 @@ spec:
                 memory: 200Mi
               limits:
                 memory: 500Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -55,11 +55,11 @@ spec:
             port: 80
     route:
       app:
-        hostnames:
-          - vaultwarden.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - vaultwarden.${DOMAIN}
     persistence:
       data:
         existingClaim: vaultwarden

--- a/kubernetes/apps/default/vaultwarden/ks.yaml
+++ b/kubernetes/apps/default/vaultwarden/ks.yaml
@@ -5,28 +5,28 @@ kind: Kustomization
 metadata:
   name: vaultwarden
 spec:
-  components:
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/default/vaultwarden/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  path: ./kubernetes/apps/default/vaultwarden/app
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 2m
-  timeout: 5m
+  targetNamespace: default
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: vaultwarden
       CAPACITY: 200Mi
-  targetNamespace: default
+  prune: true
+  wait: false

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -14,12 +14,6 @@ spec:
       autobrr:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
         initContainers:
           init-db:
             image:
@@ -68,6 +62,12 @@ spec:
                 cpu: 10m
               limits:
                 memory: 256Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
     service:
       app:
         ports:
@@ -76,17 +76,13 @@ spec:
             port: *port
           metrics:
             port: 9074
-    serviceMonitor:
-      app:
-        endpoints:
-          - port: metrics
     route:
       app:
-        hostnames:
-          - autobrr.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - autobrr.${DOMAIN}
     persistence:
       config:
         existingClaim: autobrr
@@ -99,3 +95,7 @@ spec:
                 subPath: log
               - path: /tmp
                 subPath: tmp
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics

--- a/kubernetes/apps/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/downloads/autobrr/ks.yaml
@@ -5,13 +5,14 @@ kind: Kustomization
 metadata:
   name: autobrr
 spec:
-  components:
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/downloads/autobrr/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/downloads/autobrr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: cloudnative-pg-cluster
       namespace: database
@@ -19,16 +20,15 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: downloads
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: autobrr
       CAPACITY: 100Mi
-  targetNamespace: downloads
+  prune: true
+  wait: false

--- a/kubernetes/apps/downloads/cross-seed/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/cross-seed/app/helmrelease.yaml
@@ -5,22 +5,15 @@ kind: HelmRelease
 metadata:
   name: cross-seed
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
-  interval: 1h
   values:
     controllers:
       cross-seed:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -50,6 +43,13 @@ spec:
                 cpu: 10m
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:

--- a/kubernetes/apps/downloads/cross-seed/ks.yaml
+++ b/kubernetes/apps/downloads/cross-seed/ks.yaml
@@ -5,27 +5,27 @@ kind: Kustomization
 metadata:
   name: cross-seed
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/downloads/cross-seed/app
+  interval: 1h
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  interval: 1h
-  path: ./kubernetes/apps/downloads/cross-seed/app
+  targetNamespace: downloads
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: cross-seed
       CAPACITY: 1Gi
   prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
-  targetNamespace: downloads

--- a/kubernetes/apps/downloads/deduparr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/deduparr/app/helmrelease.yaml
@@ -12,16 +12,9 @@ spec:
   values:
     controllers:
       deduparr:
-        strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
+        strategy: RollingUpdate
         containers:
           app:
             image:
@@ -61,8 +54,8 @@ spec:
               startup:
                 enabled: true
                 spec:
-                  failureThreshold: 30
                   periodSeconds: 10
+                  failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -72,6 +65,13 @@ spec:
                 cpu: 10m
               limits:
                 memory: 128Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:

--- a/kubernetes/apps/downloads/deduparr/ks.yaml
+++ b/kubernetes/apps/downloads/deduparr/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: deduparr
 spec:
-  path: ./kubernetes/apps/downloads/deduparr/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/downloads/deduparr/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: downloads
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: downloads
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/downloads/mam/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/mam/app/helmrelease.yaml
@@ -5,22 +5,15 @@ kind: HelmRelease
 metadata:
   name: mam
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
     namespace: flux-system
-  interval: 1h
   values:
     controllers:
       mam:
         type: cronjob
-        cronjob:
-          schedule: "@hourly"
-          backoffLimit: 0
-          concurrencyPolicy: Forbid
-          successfulJobsHistory: 1
-          failedJobsHistory: 1
-          ttlSecondsAfterFinished: 3600
         containers:
           app:
             image:
@@ -45,7 +38,6 @@ spec:
               limits:
                 memory: 64Mi
         pod:
-          restartPolicy: Never
           annotations:
             k8s.v1.cni.cncf.io/networks: |-
               [{
@@ -58,3 +50,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 568
             runAsGroup: 568
+          restartPolicy: Never
+        cronjob:
+          schedule: "@hourly"
+          backoffLimit: 0
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+          ttlSecondsAfterFinished: 3600

--- a/kubernetes/apps/downloads/mam/ks.yaml
+++ b/kubernetes/apps/downloads/mam/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: mam
 spec:
-  path: ./kubernetes/apps/downloads/mam/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/downloads/mam/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: downloads
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: downloads
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -12,6 +12,12 @@ spec:
   values:
     defaultPodOptions:
       terminationGracePeriodSeconds: 300
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
       annotations:
         k8s.v1.cni.cncf.io/networks: |-
           [{
@@ -20,12 +26,6 @@ spec:
             "ips": ["10.0.90.8/24"],
             "mac": "32:0b:d8:1f:b6:e9"
           }]
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 568
-        runAsGroup: 568
-        fsGroup: 568
-        fsGroupChangePolicy: OnRootMismatch
     controllers:
       qbittorrent:
         annotations:
@@ -51,8 +51,8 @@ spec:
               startup:
                 enabled: true
                 spec:
-                  failureThreshold: 30
                   periodSeconds: 10
+                  failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -102,21 +102,21 @@ spec:
             port: &qbopPort 4567
     route:
       app:
-        hostnames:
-          - qb.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - qb.${DOMAIN}
         rules:
           - backendRefs:
               - name: qbittorrent
                 port: *port
       qbop:
-        hostnames:
-          - qbop.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - qbop.${DOMAIN}
         rules:
           - backendRefs:
               - name: qbittorrent
@@ -136,12 +136,12 @@ spec:
               - path: /config
       config-file:
         type: configMap
-        identifier: config
         advancedMounts:
           qbittorrent:
             app:
               - path: /config/.qbt.toml
                 subPath: .qbt.toml
+        identifier: config
       media:
         type: nfs
         server: singularity.milkyway

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -5,29 +5,29 @@ kind: Kustomization
 metadata:
   name: qbittorrent
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/downloads/qbittorrent/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/downloads/qbittorrent/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: downloads
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: qbittorrent
       CAPACITY: 100Mi
-  targetNamespace: downloads
+  prune: true
+  wait: false

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -5,22 +5,15 @@ kind: HelmRelease
 metadata:
   name: qui
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
-  interval: 1h
   values:
     controllers:
       qui:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -48,15 +41,22 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 512Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -64,11 +64,11 @@ spec:
             port: *port
     route:
       app:
-        hostnames:
-          - qui.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - qui.${DOMAIN}
     persistence:
       config:
         existingClaim: qui

--- a/kubernetes/apps/downloads/qui/ks.yaml
+++ b/kubernetes/apps/downloads/qui/ks.yaml
@@ -5,26 +5,26 @@ kind: Kustomization
 metadata:
   name: qui
 spec:
-  components:
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/downloads/qui/app
+  interval: 1h
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  interval: 1h
-  path: ./kubernetes/apps/downloads/qui/app
+  targetNamespace: downloads
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: qui
       CAPACITY: 2Gi
   prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
-  targetNamespace: downloads

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -12,13 +12,6 @@ spec:
   values:
     controllers:
       sabnzbd:
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -32,10 +25,6 @@ spec:
                 {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster,
                 {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local,
                 sabnzbd.${DOMAIN}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness: &probes
                 enabled: true
@@ -49,12 +38,23 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 300m
                 memory: 1Gi
               limits:
                 memory: 6Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -65,11 +65,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             url: https://sabnzbd.${DOMAIN}/api?mode=version
-        hostnames:
-          - sabnzbd.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - sabnzbd.${DOMAIN}
     persistence:
       config:
         existingClaim: sabnzbd

--- a/kubernetes/apps/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/ks.yaml
@@ -5,30 +5,30 @@ kind: Kustomization
 metadata:
   name: sabnzbd
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/ext-auth
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/downloads/sabnzbd/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/downloads/sabnzbd/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: downloads
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/ext-auth
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: sabnzbd
       CAPACITY: 100Mi
-  targetNamespace: downloads
+  prune: true
+  wait: false

--- a/kubernetes/apps/downloads/tqm/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/tqm/app/helmrelease.yaml
@@ -5,61 +5,11 @@ kind: HelmRelease
 metadata:
   name: tqm
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
-  interval: 1h
   values:
-    controllers:
-      tqm:
-        type: cronjob
-        cronjob: &cronJobSpec
-          schedule: 0 * * * *
-          backoffLimit: 0
-          concurrencyPolicy: Forbid
-          successfulJobsHistory: 1
-          failedJobsHistory: 1
-          ttlSecondsAfterFinished: 3600
-        initContainers:
-          retag: &container
-            image:
-              repository: ghcr.io/home-operations/tqm
-              tag: 1.20.0@sha256:c5bdff16ca1107712fd61dc6c39a276488908c702e68e427db889419af042761
-            args:
-              - retag
-              - qb
-            resources:
-              requests:
-                cpu: 10m
-              limits:
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
-        containers:
-          clean:
-            <<: *container
-            args:
-              - clean
-              - qb
-        pod:
-          restartPolicy: Never
-      orphaned:
-        type: cronjob
-        cronjob:
-          <<: *cronJobSpec
-          schedule: 0 0 * * 0
-          suspend: true
-        containers:
-          app:
-            <<: *container
-            args:
-              - orphan
-              - qb
-              - --dry-run
-        pod:
-          restartPolicy: Never
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -67,6 +17,62 @@ spec:
         runAsGroup: 568
         fsGroup: 568
         fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      tqm:
+        type: cronjob
+        initContainers:
+          retag: &container
+            image: &id001
+              repository: ghcr.io/home-operations/tqm
+              tag: 1.20.0@sha256:c5bdff16ca1107712fd61dc6c39a276488908c702e68e427db889419af042761
+            args:
+              - retag
+              - qb
+            securityContext: &id002
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources: &id003
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+        containers:
+          clean:
+            <<: *container
+            image: *id001
+            args:
+              - clean
+              - qb
+            securityContext: *id002
+            resources: *id003
+        pod:
+          restartPolicy: Never
+        cronjob: &cronJobSpec
+          schedule: 0 * * * *
+          backoffLimit: 0
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+          ttlSecondsAfterFinished: 3600
+      orphaned:
+        type: cronjob
+        containers:
+          app:
+            <<: *container
+            image: *id001
+            args:
+              - orphan
+              - qb
+              - --dry-run
+            securityContext: *id002
+            resources: *id003
+        pod:
+          restartPolicy: Never
+        cronjob:
+          <<: *cronJobSpec
+          schedule: 0 0 * * 0
+          suspend: true
     persistence:
       config:
         type: emptyDir

--- a/kubernetes/apps/downloads/tqm/ks.yaml
+++ b/kubernetes/apps/downloads/tqm/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: tqm
 spec:
-  path: ./kubernetes/apps/downloads/tqm/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/downloads/tqm/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: qbittorrent
       namespace: downloads
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: downloads
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: downloads
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: flux-instance
 spec:
-  dependsOn:
-    - name: flux-operator
-      namespace: flux-system
-  interval: 1h
-  path: ./kubernetes/apps/flux-system/flux-instance/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/flux-system/flux-instance/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
+  dependsOn:
+    - name: flux-operator
+      namespace: flux-system
   targetNamespace: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: flux-operator
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: flux-operator
-  interval: 1h
   values:
     serviceMonitor:
       create: true

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -5,23 +5,23 @@ kind: Kustomization
 metadata:
   name: flux-operator
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/flux-system/flux-operator/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
+  targetNamespace: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: flux-operator
       namespace: flux-system
-  interval: 1h
-  path: ./kubernetes/apps/flux-system/flux-operator/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  timeout: 5m
-  wait: false
-  targetNamespace: flux-system

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: konflate
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: konflate
-  interval: 1h
   values:
     config:
       repo: github://Diaoul/home-ops

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: konflate
 spec:
-  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/flux-system/konflate/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
+  targetNamespace: flux-system
   postBuild:
     substituteFrom:
       - kind: Secret
         name: cluster-secrets
   prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: flux-system
-  timeout: 5m
   wait: false

--- a/kubernetes/apps/home-automation/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/esphome/app/helmrelease.yaml
@@ -12,13 +12,6 @@ spec:
   values:
     controllers:
       esphome:
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -36,8 +29,8 @@ spec:
               startup:
                 enabled: true
                 spec:
-                  failureThreshold: 30
                   periodSeconds: 5
+                  failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -48,6 +41,13 @@ spec:
                 memory: 500Mi
               limits:
                 memory: 4Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -56,11 +56,11 @@ spec:
     route:
       app:
         enabled: true
-        hostnames:
-          - esphome.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - esphome.${DOMAIN}
     persistence:
       config:
         existingClaim: esphome

--- a/kubernetes/apps/home-automation/esphome/ks.yaml
+++ b/kubernetes/apps/home-automation/esphome/ks.yaml
@@ -5,28 +5,28 @@ kind: Kustomization
 metadata:
   name: esphome
 spec:
-  components:
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/home-automation/esphome/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/home-automation/esphome/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: home-automation
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: esphome
       CAPACITY: 3Gi
-  targetNamespace: home-automation
+  prune: true
+  wait: false

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -14,12 +14,6 @@ spec:
       frigate:
         annotations:
           configmap.reloader.stakater.com/reload: frigate-config
-        pod:
-          nodeSelector:
-            feature.node.kubernetes.io/custom-google-coral: "true"
-          resourceClaims:
-            - name: gpu
-              resourceClaimTemplateName: frigate
         containers:
           app:
             image:
@@ -50,6 +44,12 @@ spec:
                 memory: 4Gi
               claims:
                 - name: gpu
+        pod:
+          nodeSelector:
+            feature.node.kubernetes.io/custom-google-coral: "true"
+          resourceClaims:
+            - name: gpu
+              resourceClaimTemplateName: frigate
     service:
       app:
         ports:
@@ -58,11 +58,11 @@ spec:
     route:
       app:
         enabled: true
-        hostnames:
-          - frigate.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - frigate.${DOMAIN}
     persistence:
       data:
         existingClaim: frigate

--- a/kubernetes/apps/home-automation/frigate/ks.yaml
+++ b/kubernetes/apps/home-automation/frigate/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: frigate
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/home-automation/frigate/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/home-automation/frigate/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: mosquitto
       namespace: database
@@ -24,16 +24,16 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: home-automation
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: frigate
       CAPACITY: 5Gi
-  targetNamespace: home-automation
+  prune: true
+  wait: false

--- a/kubernetes/apps/home-automation/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/go2rtc/app/helmrelease.yaml
@@ -14,11 +14,6 @@ spec:
       go2rtc:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
         containers:
           app:
             image:
@@ -46,6 +41,11 @@ spec:
                 cpu: 10m
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
     service:
       app:
         type: LoadBalancer
@@ -67,11 +67,11 @@ spec:
     route:
       app:
         enabled: true
-        hostnames:
-          - go2rtc.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - go2rtc.${DOMAIN}
     persistence:
       config:
         type: configMap

--- a/kubernetes/apps/home-automation/go2rtc/ks.yaml
+++ b/kubernetes/apps/home-automation/go2rtc/ks.yaml
@@ -5,20 +5,20 @@ kind: Kustomization
 metadata:
   name: go2rtc
 spec:
-  path: ./kubernetes/apps/home-automation/go2rtc/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/home-automation/go2rtc/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: home-automation
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: go2rtc
-  targetNamespace: home-automation
+  prune: true
+  wait: false

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       home-assistant:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -57,6 +50,13 @@ spec:
                 cpu: 10m
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -70,21 +70,21 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             conditions: ["[STATUS] == 200"]
-        hostnames:
-          - hass.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - hass.${DOMAIN}
         rules:
           - backendRefs:
               - name: home-assistant
                 port: *port
       code-server:
-        hostnames:
-          - hass-code.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - hass-code.${DOMAIN}
         rules:
           - backendRefs:
               - name: home-assistant

--- a/kubernetes/apps/home-automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/ks.yaml
@@ -5,13 +5,14 @@ kind: Kustomization
 metadata:
   name: home-assistant
 spec:
-  components:
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/home-automation/home-assistant/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/home-automation/home-assistant/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: mosquitto
       namespace: database
@@ -19,16 +20,15 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: home-automation
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: home-assistant
       CAPACITY: 5Gi
-  targetNamespace: home-automation
+  prune: true
+  wait: false

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       zigbee2mqtt:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -70,8 +63,8 @@ spec:
               startup:
                 enabled: true
                 spec:
-                  failureThreshold: 30
                   periodSeconds: 10
+                  failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -86,6 +79,13 @@ spec:
                 memory: 300Mi
               limits:
                 memory: 500Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -93,11 +93,11 @@ spec:
             port: 8080
     route:
       app:
-        hostnames:
-          - zigbee2mqtt.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - zigbee2mqtt.${DOMAIN}
     persistence:
       data:
         existingClaim: zigbee2mqtt

--- a/kubernetes/apps/home-automation/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/ks.yaml
@@ -5,13 +5,14 @@ kind: Kustomization
 metadata:
   name: zigbee2mqtt
 spec:
-  components:
-    - ../../../../components/persistence
-  path: ./kubernetes/apps/home-automation/zigbee2mqtt/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/home-automation/zigbee2mqtt/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: mosquitto
       namespace: database
@@ -19,16 +20,15 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: home-automation
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: zigbee2mqtt
       CAPACITY: 500Mi
-  targetNamespace: home-automation
+  prune: true
+  wait: false

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: kopiur
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: kopiur
-  interval: 1h
   values:
     resources:
       requests:

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -6,20 +6,20 @@ metadata:
   name: kopiur
   namespace: flux-system
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  interval: 1h
+  targetNamespace: kopiur-system
+  prune: true
+  wait: false
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: kopiur
       namespace: kopiur-system
-  interval: 1h
-  path: ./kubernetes/apps/kopiur-system/kopiur/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: kopiur-system
-  wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -28,16 +28,16 @@ metadata:
   name: kopiur-repository
   namespace: flux-system
 spec:
-  dependsOn:
-    - name: kopiur
-    - name: miroir-config
-      namespace: miroir-system
-  interval: 1h
-  path: ./kubernetes/apps/kopiur-system/kopiur/repository
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  interval: 1h
+  dependsOn:
+    - name: kopiur
+    - name: miroir-config
+      namespace: miroir-system
   targetNamespace: kopiur-system
+  prune: true
   wait: false

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: cilium
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/cilium/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/cilium/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: kube-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: coredns
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/coredns/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/coredns/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: kube-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/kube-system/descheduler/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: descheduler
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/descheduler/app
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/descheduler/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: kube-system
+  prune: true
+  wait: false

--- a/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-gpu-resource-driver/ks.yaml
@@ -5,16 +5,16 @@ kind: Kustomization
 metadata:
   name: intel-gpu-resource-driver
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/kube-system/intel-gpu-resource-driver/app
+  interval: 1h
+  targetNamespace: kube-system
+  prune: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: intel-gpu-resource-driver
       namespace: kube-system
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/intel-gpu-resource-driver/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: kube-system

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: metrics-server
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/metrics-server/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/metrics-server/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: kube-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
+++ b/kubernetes/apps/kube-system/node-feature-discovery/ks.yaml
@@ -5,17 +5,17 @@ kind: Kustomization
 metadata:
   name: node-feature-discovery
 spec:
-  path: ./kubernetes/apps/kube-system/node-feature-discovery/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/node-feature-discovery/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: kube-system
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: kube-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -23,17 +23,17 @@ kind: Kustomization
 metadata:
   name: node-feature-discovery-rules
 spec:
-  dependsOn:
-    - name: node-feature-discovery
-      namespace: kube-system
-  path: ./kubernetes/apps/kube-system/node-feature-discovery/rules
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/node-feature-discovery/rules
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  dependsOn:
+    - name: node-feature-discovery
+      namespace: kube-system
+  targetNamespace: kube-system
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: kube-system

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: reloader
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/reloader/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/reloader/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: kube-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -5,19 +5,19 @@ kind: Kustomization
 metadata:
   name: snapshot-controller
 spec:
-  path: ./kubernetes/apps/kube-system/snapshot-controller/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/snapshot-controller/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
+  targetNamespace: kube-system
+  prune: true
+  wait: false
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: snapshot-controller
       namespace: kube-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 2m
-  timeout: 5m
-  targetNamespace: kube-system

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: spegel
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/kube-system/spegel/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/kube-system/spegel/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: kube-system
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -12,13 +12,6 @@ spec:
   values:
     controllers:
       audiobookshelf:
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -52,6 +45,13 @@ spec:
                 memory: 150Mi
               limits:
                 memory: 1Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -59,11 +59,11 @@ spec:
             port: *port
     route:
       app:
-        hostnames:
-          - audiobookshelf.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - audiobookshelf.${DOMAIN}
     persistence:
       config:
         existingClaim: audiobookshelf

--- a/kubernetes/apps/media/audiobookshelf/ks.yaml
+++ b/kubernetes/apps/media/audiobookshelf/ks.yaml
@@ -5,29 +5,29 @@ kind: Kustomization
 metadata:
   name: audiobookshelf
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/audiobookshelf/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: audiobookshelf
       CAPACITY: 500Mi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       bazarr:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -33,10 +26,6 @@ spec:
             envFrom:
               - secretRef:
                   name: bazarr
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness:
                 enabled: true
@@ -57,13 +46,24 @@ spec:
               startup:
                 enabled: true
                 spec:
-                  failureThreshold: 30
                   periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -74,11 +74,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             url: https://bazarr.${DOMAIN}/api/system/ping
-        hostnames:
-          - bazarr.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - bazarr.${DOMAIN}
     persistence:
       config:
         existingClaim: bazarr

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -5,30 +5,30 @@ kind: Kustomization
 metadata:
   name: bazarr
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/ext-auth
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/bazarr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/ext-auth
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: bazarr
       CAPACITY: 1Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/flaresolverr/ks.yaml
+++ b/kubernetes/apps/media/flaresolverr/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: flaresolverr
 spec:
-  path: ./kubernetes/apps/media/flaresolverr/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/media/flaresolverr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: media
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: media

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -12,19 +12,6 @@ spec:
   values:
     controllers:
       jellyfin:
-        pod:
-          resourceClaims:
-            - name: gpu
-              resourceClaimTemplateName: jellyfin
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
-            supplementalGroups:
-              - 44 # video
-              - 109 # render
         containers:
           app:
             image:
@@ -32,10 +19,6 @@ spec:
               tag: 10.11.11@sha256:45f648c382a0c8b552582fcea40e95cb17c5d475473a891cba0eb7523fb92112
             env:
               JELLYFIN_PublishedServerUrl: https://jellyfin.${DOMAIN}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness: &probes
                 enabled: true
@@ -54,6 +37,10 @@ spec:
                 spec:
                   periodSeconds: 10
                   failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 100m
@@ -62,6 +49,19 @@ spec:
                 memory: 8Gi
               claims:
                 - name: gpu
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups:
+              - 44 # video
+              - 109 # render
+          resourceClaims:
+            - name: gpu
+              resourceClaimTemplateName: jellyfin
     service:
       app:
         ports:
@@ -69,11 +69,11 @@ spec:
             port: *port
     route:
       app:
-        hostnames:
-          - jellyfin.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - jellyfin.${DOMAIN}
     persistence:
       config:
         existingClaim: jellyfin

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -5,6 +5,14 @@ kind: Kustomization
 metadata:
   name: jellyfin
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/media/jellyfin/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
   dependsOn:
     - name: intel-gpu-resource-driver
       namespace: kube-system
@@ -12,24 +20,16 @@ spec:
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
+  targetNamespace: media
   components:
     - ../../../../components/zeroscaler
     - ../../../../components/persistence
-  path: ./kubernetes/apps/media/jellyfin/app
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 2m
-  timeout: 5m
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: jellyfin
       CAPACITY: 20Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -12,13 +12,6 @@ spec:
   values:
     controllers:
       jellyseerr:
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -49,6 +42,13 @@ spec:
                 memory: 250Mi
               limits:
                 memory: 500Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -59,11 +59,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             conditions: ["[STATUS] == 200"]
-        hostnames:
-          - jellyseerr.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - jellyseerr.${DOMAIN}
     persistence:
       config:
         existingClaim: jellyseerr

--- a/kubernetes/apps/media/jellyseerr/ks.yaml
+++ b/kubernetes/apps/media/jellyseerr/ks.yaml
@@ -5,28 +5,28 @@ kind: Kustomization
 metadata:
   name: jellyseerr
 spec:
-  components:
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/jellyseerr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: jellyseerr
       CAPACITY: 2Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/kavita/app/helmrelease.yaml
+++ b/kubernetes/apps/media/kavita/app/helmrelease.yaml
@@ -12,13 +12,6 @@ spec:
   values:
     controllers:
       kavita:
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -34,6 +27,13 @@ spec:
                 memory: 800Mi
               limits:
                 memory: 2Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -41,11 +41,11 @@ spec:
             port: 5000
     route:
       app:
-        hostnames:
-          - kavita.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - kavita.${DOMAIN}
     persistence:
       config:
         existingClaim: kavita

--- a/kubernetes/apps/media/kavita/ks.yaml
+++ b/kubernetes/apps/media/kavita/ks.yaml
@@ -5,29 +5,29 @@ kind: Kustomization
 metadata:
   name: kavita
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/kavita/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: kavita
       CAPACITY: 500Mi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       prowlarr:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -32,10 +25,6 @@ spec:
             envFrom:
               - secretRef:
                   name: prowlarr
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness: &probes
                 enabled: true
@@ -49,12 +38,23 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 100m
                 memory: 600Mi
               limits:
                 memory: 1Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -65,11 +65,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             url: https://prowlarr.${DOMAIN}/ping
-        hostnames:
-          - prowlarr.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - prowlarr.${DOMAIN}
     persistence:
       config:
         existingClaim: prowlarr

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -5,29 +5,29 @@ kind: Kustomization
 metadata:
   name: prowlarr
 spec:
-  components:
-    - ../../../../components/ext-auth
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/prowlarr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/ext-auth
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: prowlarr
       CAPACITY: 1Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       radarr:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -32,10 +25,6 @@ spec:
             envFrom:
               - secretRef:
                   name: radarr
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness: &probes
                 enabled: true
@@ -49,12 +38,23 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 200m
                 memory: 500Mi
               limits:
                 memory: 1Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -65,11 +65,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             url: https://radarr.${DOMAIN}/ping
-        hostnames:
-          - radarr.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - radarr.${DOMAIN}
     persistence:
       config:
         existingClaim: radarr

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -5,30 +5,30 @@ kind: Kustomization
 metadata:
   name: radarr
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/ext-auth
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/radarr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/ext-auth
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: radarr
       CAPACITY: 1Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -13,28 +13,17 @@ spec:
     controllers:
       recyclarr:
         type: cronjob
-        cronjob:
-          schedule: "@daily"
-          successfulJobsHistory: 1
-          failedJobsHistory: 1
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
               repository: ghcr.io/recyclarr/recyclarr
               tag: 8.7.1@sha256:73303ba5ee647b6492fee917d3a781c6e59b6cab08f9dfce9482a950846f564f
-            env:
-              COMPlus_EnableDiagnostics: "0"
             args:
               - sync
+            env:
+              COMPlus_EnableDiagnostics: "0"
             envFrom:
               - secretRef:
                   name: sonarr
@@ -50,6 +39,17 @@ spec:
                 memory: 100M
               limits:
                 memory: 200M
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+        cronjob:
+          schedule: "@daily"
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
     persistence:
       config:
         existingClaim: recyclarr

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -5,28 +5,28 @@ kind: Kustomization
 metadata:
   name: recyclarr
 spec:
-  components:
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/recyclarr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: recyclarr
       CAPACITY: 1Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -23,13 +23,6 @@ spec:
       shelfmark:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -79,8 +72,8 @@ spec:
               startup:
                 enabled: true
                 spec:
-                  failureThreshold: 30
                   periodSeconds: 10
+                  failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -91,6 +84,13 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         controller: shelfmark
@@ -99,11 +99,11 @@ spec:
             port: *port
     route:
       app:
-        hostnames:
-          - shelfmark.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - shelfmark.${DOMAIN}
         rules:
           - backendRefs:
               - name: shelfmark

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -5,29 +5,29 @@ kind: Kustomization
 metadata:
   name: shelfmark
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/shelfmark/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: shelfmark
       CAPACITY: 1Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -14,13 +14,6 @@ spec:
       sonarr:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
-            fsGroup: 568
-            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -32,10 +25,6 @@ spec:
             envFrom:
               - secretRef:
                   name: sonarr
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
             probes:
               liveness: &probes
                 enabled: true
@@ -49,12 +38,23 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 200m
                 memory: 800Mi
               limits:
                 memory: 1Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         ports:
@@ -65,11 +65,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             url: https://sonarr.${DOMAIN}/ping
-        hostnames:
-          - sonarr.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - sonarr.${DOMAIN}
     persistence:
       config:
         existingClaim: sonarr

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -5,30 +5,30 @@ kind: Kustomization
 metadata:
   name: sonarr
 spec:
-  components:
-    - ../../../../components/zeroscaler
-    - ../../../../components/ext-auth
-    - ../../../../components/persistence
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
   path: ./kubernetes/apps/media/sonarr/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: kopiur-repository
       namespace: kopiur-system
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: media
+  components:
+    - ../../../../components/zeroscaler
+    - ../../../../components/ext-auth
+    - ../../../../components/persistence
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: sonarr
       CAPACITY: 1Gi
-  targetNamespace: media
+  prune: true
+  wait: false

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: miroir
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: miroir
-  interval: 1h
   values:
     autoEvictAfter: 1h
     drbd:

--- a/kubernetes/apps/miroir-system/miroir/ks.yaml
+++ b/kubernetes/apps/miroir-system/miroir/ks.yaml
@@ -5,17 +5,17 @@ kind: Kustomization
 metadata:
   name: miroir
 spec:
-  dependsOn:
-    - name: snapshot-controller
-      namespace: kube-system
-  interval: 1h
-  path: ./kubernetes/apps/miroir-system/miroir/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/miroir-system/miroir/app
+  interval: 1h
+  dependsOn:
+    - name: snapshot-controller
+      namespace: kube-system
   targetNamespace: miroir-system
+  prune: true
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -24,14 +24,14 @@ kind: Kustomization
 metadata:
   name: miroir-config
 spec:
-  dependsOn:
-    - name: miroir
-  interval: 1h
-  path: ./kubernetes/apps/miroir-system/miroir/config
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/miroir-system/miroir/config
+  interval: 1h
+  dependsOn:
+    - name: miroir
   targetNamespace: miroir-system
+  prune: true
   wait: true

--- a/kubernetes/apps/network/cloudflare-dns/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/ks.yaml
@@ -5,6 +5,21 @@ kind: Kustomization
 metadata:
   name: cloudflare-dns
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/network/cloudflare-dns/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 2m
+  targetNamespace: network
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -13,18 +28,3 @@ spec:
     - apiVersion: apiextensions.k8s.io/v1
       kind: CustomResourceDefinition
       name: dnsendpoints.externaldns.k8s.io
-  interval: 1h
-  path: ./kubernetes/apps/network/cloudflare-dns/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  timeout: 5m
-  wait: true
-  targetNamespace: network

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -12,19 +12,17 @@ spec:
   values:
     controllers:
       cloudflare-tunnel:
-        strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+        strategy: RollingUpdate
         containers:
           app:
             image:
               repository: docker.io/cloudflare/cloudflared
               tag: 2026.8.2
+            args:
+              - tunnel
+              - run
             env:
               NO_AUTOUPDATE: true
               TUNNEL_METRICS: 0.0.0.0:8080
@@ -34,9 +32,6 @@ spec:
             envFrom:
               - secretRef:
                   name: cloudflare-tunnel
-            args:
-              - tunnel
-              - run
             probes:
               liveness: &probes
                 enabled: true
@@ -59,15 +54,16 @@ spec:
                 cpu: 10m
               limits:
                 memory: 256Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
     service:
       app:
         ports:
           http:
             port: *port
-    serviceMonitor:
-      app:
-        endpoints:
-          - port: http
     persistence:
       config-file:
         type: configMap
@@ -76,3 +72,7 @@ spec:
           - path: /etc/cloudflared/config.yaml
             subPath: config.yaml
             readOnly: true
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: cloudflare-tunnel
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/network/cloudflare-tunnel/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/network/cloudflare-tunnel/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: network
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/network/e1000e-fix/app/helmrelease.yaml
+++ b/kubernetes/apps/network/e1000e-fix/app/helmrelease.yaml
@@ -13,13 +13,6 @@ spec:
     controllers:
       e1000e-fix:
         type: daemonset
-        pod:
-          automountServiceAccountToken: false
-          enableServiceLinks: false
-          hostNetwork: true
-          hostPID: true
-          nodeSelector:
-            feature.node.kubernetes.io/custom-e1000e: "true"
         containers:
           app:
             image:
@@ -54,6 +47,13 @@ spec:
                 cpu: 10m
               limits:
                 memory: 10Mi
+        pod:
+          hostNetwork: true
+          nodeSelector:
+            feature.node.kubernetes.io/custom-e1000e: "true"
+          automountServiceAccountToken: false
+          enableServiceLinks: false
+          hostPID: true
     persistence:
       procfs:
         type: hostPath

--- a/kubernetes/apps/network/e1000e-fix/ks.yaml
+++ b/kubernetes/apps/network/e1000e-fix/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: e1000e-fix
 spec:
-  path: ./kubernetes/apps/network/e1000e-fix/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/network/e1000e-fix/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: network
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: network

--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -5,19 +5,14 @@ kind: HelmRelease
 metadata:
   name: echo
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: app-template
-  interval: 1h
   values:
     controllers:
       echo:
         strategy: RollingUpdate
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
         containers:
           app:
             image:
@@ -50,22 +45,27 @@ spec:
                 cpu: 10m
               limits:
                 memory: 64Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
     service:
       app:
         ports:
           http:
             port: *port
-    serviceMonitor:
-      app:
-        endpoints:
-          - port: http
     route:
       app:
         annotations:
           gatus.home-operations.com/endpoint: |-
             conditions: ["[STATUS] == 200"]
-        hostnames:
-          - echo.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - echo.${DOMAIN}
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http

--- a/kubernetes/apps/network/echo/ks.yaml
+++ b/kubernetes/apps/network/echo/ks.yaml
@@ -5,16 +5,16 @@ kind: Kustomization
 metadata:
   name: echo
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/network/echo/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/network/echo/app
+  interval: 1h
   targetNamespace: network
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
   wait: false

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -5,20 +5,20 @@ kind: Kustomization
 metadata:
   name: envoy-gateway
 spec:
-  dependsOn:
-    - name: cert-manager
-      namespace: cert-manager
-  interval: 1h
-  path: ./kubernetes/apps/network/envoy-gateway/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/network/envoy-gateway/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
   targetNamespace: network
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/network/k8s-gateway/ks.yaml
+++ b/kubernetes/apps/network/k8s-gateway/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: k8s-gateway
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/network/k8s-gateway/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/network/k8s-gateway/app
+  interval: 1h
   timeout: 5m
-  wait: false
+  retryInterval: 2m
   targetNamespace: network
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: multus
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: multus
-  interval: 1h
   values:
     cni:
       binPath: /opt/cni/bin

--- a/kubernetes/apps/network/multus/ks.yaml
+++ b/kubernetes/apps/network/multus/ks.yaml
@@ -5,6 +5,14 @@ kind: Kustomization
 metadata:
   name: multus
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/network/multus/app
+  interval: 1h
+  targetNamespace: network
+  prune: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -13,14 +21,6 @@ spec:
     - apiVersion: apiextensions.k8s.io/v1
       kind: CustomResourceDefinition
       name: network-attachment-definitions.k8s.cni.cncf.io
-  interval: 1h
-  path: ./kubernetes/apps/network/multus/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: network
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -28,14 +28,14 @@ kind: Kustomization
 metadata:
   name: multus-networks
 spec:
-  dependsOn:
-    - name: multus
-  interval: 1h
-  path: ./kubernetes/apps/network/multus/networks
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/network/multus/networks
+  interval: 1h
+  dependsOn:
+    - name: multus
   targetNamespace: network
+  prune: true
   wait: true

--- a/kubernetes/apps/network/singularity/ks.yaml
+++ b/kubernetes/apps/network/singularity/ks.yaml
@@ -5,20 +5,20 @@ kind: Kustomization
 metadata:
   name: singularity
 spec:
-  path: ./kubernetes/apps/network/singularity/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/network/singularity/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: network
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: singularity
-  targetNamespace: network
+  prune: true
+  wait: false

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -5,16 +5,16 @@ kind: Kustomization
 metadata:
   name: blackbox-exporter
 spec:
-  path: ./kubernetes/apps/observability/blackbox-exporter/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
+  path: ./kubernetes/apps/observability/blackbox-exporter/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: kube-prometheus-stack
   targetNamespace: observability
+  prune: true
+  wait: false

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: gatus
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: gatus-sidecar
-  interval: 1h
   values:
     deploymentAnnotations:
       reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: gatus
 spec:
-  path: ./kubernetes/apps/observability/gatus/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/observability/gatus/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: observability
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: observability
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/observability/grafana-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-operator/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: grafana-operator
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: grafana-operator
-  interval: 1h
   values:
     dashboard:
       enabled: true

--- a/kubernetes/apps/observability/grafana-operator/ks.yaml
+++ b/kubernetes/apps/observability/grafana-operator/ks.yaml
@@ -5,18 +5,18 @@ kind: Kustomization
 metadata:
   name: grafana-operator
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/observability/grafana-operator/app
-  prune: true
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/grafana-operator/app
+  interval: 1h
   targetNamespace: observability
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -25,22 +25,22 @@ kind: Kustomization
 metadata:
   name: grafana-operator-instance
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/observability/grafana-operator/instance
+  interval: 1h
   dependsOn:
     - name: grafana-operator
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: authelia
       namespace: security
+  targetNamespace: observability
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  interval: 1h
-  path: ./kubernetes/apps/observability/grafana-operator/instance
+      - kind: Secret
+        name: cluster-secrets
   prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: observability
   wait: false

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -14,11 +14,6 @@ spec:
       kromgo:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
         containers:
           app:
             image:
@@ -48,6 +43,11 @@ spec:
                 cpu: 10m
               limits:
                 memory: 64Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
     service:
       app:
         ports:
@@ -61,11 +61,11 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             conditions: ["[STATUS] == 200"]
-        hostnames:
-          - kromgo.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - kromgo.${DOMAIN}
     persistence:
       config-file:
         type: configMap

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -5,20 +5,20 @@ kind: Kustomization
 metadata:
   name: kromgo
 spec:
-  path: ./kubernetes/apps/observability/kromgo/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  prune: true
-  wait: false
+  path: ./kubernetes/apps/observability/kromgo/app
   interval: 1h
-  retryInterval: 1m
   timeout: 5m
+  retryInterval: 1m
+  targetNamespace: observability
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: kromgo
-  targetNamespace: observability
+  prune: true
+  wait: false

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: kube-prometheus-stack
-  interval: 1h
   valuesFrom:
     - kind: ConfigMap
       name: flux-metrics-configmap

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -5,19 +5,19 @@ kind: Kustomization
 metadata:
   name: kube-prometheus-stack
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/observability/kube-prometheus-stack/app
+  interval: 1h
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-  interval: 1h
-  path: ./kubernetes/apps/observability/kube-prometheus-stack/app
+  targetNamespace: observability
   postBuild:
     substituteFrom:
       - kind: Secret
         name: cluster-secrets
   prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: observability
   wait: false

--- a/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
@@ -12,23 +12,11 @@ spec:
   values:
     controllers:
       network-ups-tools:
-        pod:
-          annotations:
-            configmap.reloader.stakater.com/reload: &config network-ups-tools-config
-          nodeSelector:
-            feature.node.kubernetes.io/custom-ups-apc: "true"
         containers:
           app:
             image:
               repository: ghcr.io/jr0dd/network-ups-tools
               tag: v2.8.3@sha256:9f8e14d155c6ef05940cee6f8861e259e951eb11750aeddd02539d986dac1ca0
-            resources:
-              requests:
-                cpu: 25m
-                memory: 64Mi
-              limits:
-                cpu: 50m
-                memory: 128Mi
             probes:
               liveness:
                 enabled: true
@@ -36,6 +24,18 @@ spec:
                 enabled: true
             securityContext:
               privileged: true
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                cpu: 50m
+                memory: 128Mi
+        pod:
+          annotations:
+            configmap.reloader.stakater.com/reload: &config network-ups-tools-config
+          nodeSelector:
+            feature.node.kubernetes.io/custom-ups-apc: "true"
     service:
       app:
         type: LoadBalancer

--- a/kubernetes/apps/observability/network-ups-tools/ks.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: network-ups-tools
 spec:
-  path: ./kubernetes/apps/observability/network-ups-tools/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/network-ups-tools/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: observability
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: observability

--- a/kubernetes/apps/observability/nut-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/nut-exporter/app/helmrelease.yaml
@@ -46,10 +46,10 @@ spec:
         enabled: true
         serviceName: nut-exporter
         endpoints:
-          - interval: 30s
-            path: /ups_metrics
-            port: metrics
+          - port: metrics
             scheme: http
+            path: /ups_metrics
+            interval: 30s
             scrapeTimeout: 15s
             metricRelabelings:
               - action: replace

--- a/kubernetes/apps/observability/nut-exporter/ks.yaml
+++ b/kubernetes/apps/observability/nut-exporter/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: nut-exporter
 spec:
-  path: ./kubernetes/apps/observability/nut-exporter/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/nut-exporter/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: observability
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: observability

--- a/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: prometheus-adapter
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: prometheus-adapter
-  interval: 1h
   values:
     prometheus:
       url: http://prometheus-operated.observability.svc.cluster.local

--- a/kubernetes/apps/observability/prometheus-adapter/ks.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/ks.yaml
@@ -6,12 +6,12 @@ metadata:
   name: prometheus-adapter
   namespace: flux-system
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/observability/prometheus-adapter/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/prometheus-adapter/app
+  interval: 1h
   targetNamespace: observability
+  prune: true
   wait: false

--- a/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/silence-operator/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: silence-operator
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: silence-operator
-  interval: 1h
   values:
     alertmanagerAddress: http://alertmanager-operated.observability.svc.cluster.local:9093
     networkPolicy:

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: silence-operator
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/observability/silence-operator/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/silence-operator/app
+  interval: 1h
   targetNamespace: observability
+  prune: true
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,14 +21,14 @@ kind: Kustomization
 metadata:
   name: silence-operator-silences
 spec:
-  dependsOn:
-    - name: silence-operator
-  interval: 1h
-  path: ./kubernetes/apps/observability/silence-operator/silences
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/silence-operator/silences
+  interval: 1h
+  dependsOn:
+    - name: silence-operator
   targetNamespace: observability
+  prune: true
   wait: false

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: smartctl-exporter
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: smartctl-exporter
-  interval: 1h
   values:
     fullnameOverride: smartctl-exporter
     serviceMonitor:

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -5,12 +5,12 @@ kind: Kustomization
 metadata:
   name: smartctl-exporter
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/observability/smartctl-exporter/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/smartctl-exporter/app
+  interval: 1h
   targetNamespace: observability
+  prune: true
   wait: false

--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -14,11 +14,6 @@ spec:
       unpoller:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
         containers:
           app:
             image:
@@ -53,6 +48,11 @@ spec:
                 memory: 64M
               limits:
                 memory: 128M
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
     service:
       app:
         ports:

--- a/kubernetes/apps/observability/unpoller/ks.yaml
+++ b/kubernetes/apps/observability/unpoller/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: unpoller
 spec:
-  path: ./kubernetes/apps/observability/unpoller/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/unpoller/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
+  targetNamespace: observability
   prune: true
   wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
-  targetNamespace: observability

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: victoria-logs
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: victoria-logs
-  interval: 1h
   values:
     fullnameOverride: victoria-logs
     global:

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: victoria-logs
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
-  interval: 1h
-  path: ./kubernetes/apps/observability/victoria-logs/app
-  prune: true
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/victoria-logs/app
+  interval: 1h
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   targetNamespace: observability
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -29,14 +29,14 @@ metadata:
   name: victoria-logs-collector
   namespace: flux-system
 spec:
-  dependsOn:
-    - name: victoria-logs
-  interval: 1h
-  path: ./kubernetes/apps/observability/victoria-logs/collector
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/observability/victoria-logs/collector
+  interval: 1h
+  dependsOn:
+    - name: victoria-logs
   targetNamespace: observability
+  prune: true
   wait: false

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -5,17 +5,17 @@ kind: Kustomization
 metadata:
   name: ceph-csi-drivers
 spec:
-  dependsOn:
-    - name: rook-ceph
-      namespace: rook-ceph
-  interval: 1h
-  path: ./kubernetes/apps/rook-ceph/ceph-csi-drivers/app
-  prune: true
-  retryInterval: 2m
-  wait: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: rook-ceph
+  path: ./kubernetes/apps/rook-ceph/ceph-csi-drivers/app
+  interval: 1h
   timeout: 5m
+  retryInterval: 2m
+  dependsOn:
+    - name: rook-ceph
+      namespace: rook-ceph
+  targetNamespace: rook-ceph
+  prune: true
+  wait: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -5,17 +5,17 @@ kind: Kustomization
 metadata:
   name: rook-ceph
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/rook-ceph/rook-ceph/app
-  prune: true
-  retryInterval: 2m
-  wait: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/app
+  interval: 1h
   timeout: 5m
+  retryInterval: 2m
   targetNamespace: rook-ceph
+  prune: true
+  wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -23,11 +23,27 @@ kind: Kustomization
 metadata:
   name: rook-ceph-cluster
 spec:
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
+  interval: 1h
+  timeout: 15m
+  retryInterval: 2m
   dependsOn:
     - name: ceph-csi-drivers
       namespace: rook-ceph
     - name: rook-ceph
       namespace: rook-ceph
+  targetNamespace: rook-ceph
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+    substitute:
+      APP: rook-ceph-cluster
+  prune: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
@@ -40,21 +56,5 @@ spec:
   healthCheckExprs:
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
-      failed: status.ceph.health == 'HEALTH_ERR'
       current: status.ceph.health in ['HEALTH_OK', 'HEALTH_WARN']
-  interval: 1h
-  path: ./kubernetes/apps/rook-ceph/rook-ceph/cluster
-  postBuild:
-    substitute:
-      APP: rook-ceph-cluster
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  timeout: 15m
-  targetNamespace: rook-ceph
+      failed: status.ceph.health == 'HEALTH_ERR'

--- a/kubernetes/apps/security/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authelia/app/helmrelease.yaml
@@ -12,15 +12,10 @@ spec:
   values:
     controllers:
       authelia:
-        replicas: 2
-        strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 568
-            runAsGroup: 568
+        strategy: RollingUpdate
+        replicas: 2
         initContainers:
           init-db:
             image:
@@ -65,6 +60,11 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 128Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
     service:
       app:
         ports:
@@ -73,17 +73,13 @@ spec:
             port: *port
           metrics:
             port: 9959
-    serviceMonitor:
-      app:
-        endpoints:
-          - port: metrics
     route:
       app:
-        hostnames:
-          - auth.${DOMAIN}
         parentRefs:
           - name: envoy-external
             namespace: network
+        hostnames:
+          - auth.${DOMAIN}
     persistence:
       config:
         type: configMap
@@ -98,3 +94,7 @@ spec:
         globalMounts:
           - path: /config/secrets
             readOnly: true
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics

--- a/kubernetes/apps/security/authelia/ks.yaml
+++ b/kubernetes/apps/security/authelia/ks.yaml
@@ -5,18 +5,14 @@ kind: Kustomization
 metadata:
   name: authelia
 spec:
-  path: ./kubernetes/apps/security/authelia/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  components:
-    - ../../../../components/dragonfly
-  healthCheckExprs:
-    - apiVersion: dragonflydb.io/v1alpha1
-      kind: Dragonfly
-      failed: status.phase != 'ready'
-      current: status.phase == 'ready'
+  path: ./kubernetes/apps/security/authelia/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: cloudnative-pg-cluster
       namespace: database
@@ -24,16 +20,20 @@ spec:
       namespace: database
     - name: lldap
       namespace: security
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: security
+  components:
+    - ../../../../components/dragonfly
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+      - kind: Secret
+        name: cluster-secrets
     substitute:
       APP: authelia
       DRAGONFLY_REPLICAS: "3"
-  targetNamespace: security
+  prune: true
+  wait: false
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      current: status.phase == 'ready'
+      failed: status.phase != 'ready'

--- a/kubernetes/apps/security/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/security/lldap/app/helmrelease.yaml
@@ -56,11 +56,11 @@ spec:
             port: 3890
     route:
       app:
-        hostnames:
-          - lldap.${DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network
+        hostnames:
+          - lldap.${DOMAIN}
     persistence:
       data:
         type: emptyDir

--- a/kubernetes/apps/security/lldap/ks.yaml
+++ b/kubernetes/apps/security/lldap/ks.yaml
@@ -5,21 +5,21 @@ kind: Kustomization
 metadata:
   name: lldap
 spec:
-  path: ./kubernetes/apps/security/lldap/app
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/security/lldap/app
+  interval: 1h
+  timeout: 5m
+  retryInterval: 1m
   dependsOn:
     - name: cloudnative-pg-cluster
       namespace: database
-  prune: true
-  wait: false
-  interval: 1h
-  retryInterval: 1m
-  timeout: 5m
+  targetNamespace: security
   postBuild:
     substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-  targetNamespace: security
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  wait: false

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -5,10 +5,10 @@ kind: HelmRelease
 metadata:
   name: tuppr
 spec:
+  interval: 1h
   chartRef:
     kind: OCIRepository
     name: tuppr
-  interval: 1h
   values:
     replicaCount: 2
     monitoring:

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -5,14 +5,14 @@ kind: Kustomization
 metadata:
   name: tuppr
 spec:
-  interval: 1h
-  path: ./kubernetes/apps/system-upgrade/tuppr/app
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/system-upgrade/tuppr/app
+  interval: 1h
   targetNamespace: system-upgrade
+  prune: true
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,14 +21,14 @@ kind: Kustomization
 metadata:
   name: tuppr-upgrades
 spec:
-  dependsOn:
-    - name: tuppr
-  interval: 1h
-  path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
+  interval: 1h
+  dependsOn:
+    - name: tuppr
   targetNamespace: system-upgrade
+  prune: true
   wait: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pre-commit==4.6.2
+pytest==9.1.1
+ruamel.yaml==0.19.1
 -r ansible/requirements.txt

--- a/scripts/config/component.yaml.tpl
+++ b/scripts/config/component.yaml.tpl
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# Only the keys are read; every value here is a placeholder.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+namespace: namespace
+resources: []
+patches:
+  - target: {}
+    path: patch.yaml
+configMapGenerator:
+  - name: name
+    files: []
+    literals: []
+generatorOptions:
+  disableNameSuffixHash: true
+  labels: {}
+  annotations: {}

--- a/scripts/config/flux-kustomization.yaml.tpl
+++ b/scripts/config/flux-kustomization.yaml.tpl
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Only the keys are read; every value here is a placeholder.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app
+  namespace: flux-system
+  labels: {}
+  annotations: {}
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+    namespace: flux-system
+  path: ./kubernetes/apps
+  interval: 10m
+  timeout: 5m
+  retryInterval: 1m
+  suspend: false
+  dependsOn:
+    - name: dependency
+      namespace: namespace
+  targetNamespace: default
+  commonMetadata:
+    labels: {}
+    annotations: {}
+  components: []
+  patches:
+    - target:
+        group: group
+        version: version
+        kind: Kind
+        name: name
+        namespace: namespace
+        labelSelector: selector
+        annotationSelector: selector
+      patch: ""
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+    substitute: {}
+  prune: true
+  deletionPolicy: WaitForTermination
+  wait: true
+  force: false
+  healthChecks:
+    - apiVersion: v1
+      kind: Kind
+      name: name
+      namespace: namespace
+  healthCheckExprs:
+    - apiVersion: group/v1
+      kind: Kind
+      current: expr
+      inProgress: expr
+      failed: expr

--- a/scripts/config/helmrelease-apptemplate.yaml.tpl
+++ b/scripts/config/helmrelease-apptemplate.yaml.tpl
@@ -1,0 +1,246 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# Only the keys are read; every value here is a placeholder.
+# A "*" key stands for any name the manifest uses at that level (controller, container,
+# probe, volume), so one entry orders all of them.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: app
+  namespace: default
+  labels: {}
+  annotations: {}
+spec:
+  interval: 30m
+  timeout: 5m
+  suspend: false
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  dependsOn:
+    - name: dependency
+      namespace: namespace
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  driftDetection:
+    mode: enabled
+    ignore: []
+  maxHistory: 5
+  valuesFrom:
+    - kind: ConfigMap
+      name: values
+      valuesKey: values.yaml
+  values:
+    defaultPodOptions:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      "*":
+        enabled: true
+        type: deployment
+        annotations: {}
+        labels: {}
+        strategy: RollingUpdate
+        replicas: 1
+        rollingUpdate:
+          unavailable: 0
+        serviceAccount:
+          identifier: default
+        initContainers:
+          "*":
+            dependsOn: []
+            image:
+              repository: repo
+              tag: tag
+              pullPolicy: IfNotPresent
+            command: []
+            args: []
+            env: {}
+            envFrom: []
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {}
+            resources:
+              requests: {}
+              limits: {}
+        containers:
+          "*":
+            image:
+              repository: repo
+              tag: tag
+              pullPolicy: IfNotPresent
+            command: []
+            args: []
+            env: {}
+            envFrom: []
+            probes:
+              "*":
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                    scheme: HTTP
+                  tcpSocket:
+                    port: 80
+                  exec:
+                    command: []
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+                  successThreshold: 1
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {}
+            resources:
+              requests: {}
+              limits: {}
+        pod:
+          annotations: {}
+          labels: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 568
+            runAsGroup: 568
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+          hostNetwork: false
+          dnsPolicy: ClusterFirst
+          nodeSelector: {}
+          tolerations: []
+          affinity: {}
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector: {}
+    service:
+      "*":
+        enabled: true
+        primary: true
+        controller: controller
+        type: ClusterIP
+        annotations: {}
+        labels: {}
+        ports:
+          "*":
+            enabled: true
+            primary: true
+            port: 80
+            protocol: HTTP
+            targetPort: 80
+    route:
+      "*":
+        enabled: true
+        annotations: {}
+        labels: {}
+        parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: envoy-internal
+            namespace: network
+            sectionName: https
+        hostnames: []
+        rules:
+          - matches: []
+            backendRefs: []
+    serviceAccount:
+      "*":
+        create: true
+        name: name
+        annotations: {}
+        labels: {}
+    rbac:
+      roles: {}
+      bindings:
+        "*":
+          type: ClusterRoleBinding
+          roleRef:
+            kind: ClusterRole
+            name: name
+          subjects: []
+    configMaps:
+      "*":
+        enabled: true
+        annotations: {}
+        labels: {}
+        data: {}
+    secrets:
+      "*":
+        enabled: true
+        type: Opaque
+        annotations: {}
+        labels: {}
+        stringData: {}
+    persistence:
+      "*":
+        enabled: true
+        type: persistentVolumeClaim
+        existingClaim: claim
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        retain: false
+        name: name
+        medium: Memory
+        sizeLimit: 1Gi
+        hostPath: /path
+        hostPathType: Directory
+        server: server
+        path: /path
+        globalMounts:
+          - path: /path
+            subPath: subpath
+            readOnly: false
+        advancedMounts: {}
+    serviceMonitor:
+      "*":
+        enabled: true
+        annotations: {}
+        labels: {}
+        serviceName: service
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s
+    networkpolicies:
+      "*":
+        enabled: true
+        annotations: {}
+        labels: {}
+        controller: controller
+        podSelector: {}
+        policyTypes: []
+        rules:
+          ingress: []
+          egress: []
+    rawResources:
+      "*":
+        enabled: true
+        apiVersion: group/v1
+        kind: Kind
+        annotations: {}
+        labels: {}
+        spec: {}

--- a/scripts/config/helmrelease.yaml.tpl
+++ b/scripts/config/helmrelease.yaml.tpl
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# Only the keys are read; every value here is a placeholder.
+# Fallback for HelmReleases whose chart has no template of its own.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: app
+  namespace: default
+  labels: {}
+  annotations: {}
+spec:
+  interval: 30m
+  timeout: 5m
+  suspend: false
+  chartRef:
+    kind: OCIRepository
+    name: chart
+    namespace: flux-system
+  dependsOn:
+    - name: dependency
+      namespace: namespace
+  install:
+    createNamespace: false
+    crds: Create
+    replace: false
+    remediation:
+      retries: 3
+      remediateLastFailure: false
+      ignoreTestFailures: false
+    timeout: 5m
+  upgrade:
+    crds: Skip
+    force: false
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+      remediateLastFailure: false
+      ignoreTestFailures: false
+    timeout: 5m
+  rollback:
+    recreate: false
+    force: false
+    cleanupOnFail: true
+    timeout: 5m
+  uninstall:
+    deletionPropagation: background
+    disableHooks: false
+    keepHistory: false
+    timeout: 5m
+  test:
+    enable: false
+    timeout: 5m
+    ignoreFailures: false
+  driftDetection:
+    mode: enabled
+    ignore: []
+  maxHistory: 5
+  persistentClient: true
+  valuesFrom:
+    - kind: ConfigMap
+      name: values
+      valuesKey: values.yaml
+  values: {}

--- a/scripts/config/kustomization.yaml.tpl
+++ b/scripts/config/kustomization.yaml.tpl
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# Only the keys are read; every value here is a placeholder.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: namespace
+components: []
+resources: []
+configurations: []
+patches:
+  - target: {}
+    path: patch.yaml
+configMapGenerator:
+  - name: name
+    namespace: namespace
+    files: []
+    literals: []
+    options:
+      disableNameSuffixHash: true
+      labels: {}
+      annotations: {}
+secretGenerator:
+  - name: name
+    namespace: namespace
+    files: []
+    literals: []
+    options:
+      disableNameSuffixHash: true
+      labels: {}
+      annotations: {}
+generatorOptions:
+  disableNameSuffixHash: true
+  labels: {}
+  annotations: {}

--- a/scripts/yamlsorter/README.md
+++ b/scripts/yamlsorter/README.md
@@ -1,0 +1,53 @@
+# yamlsorter
+
+Reorders keys in this repo's Flux manifests so diffs stay readable. Key order carries
+no meaning to Kubernetes, so it is free to standardise — and worth standardising,
+because an unordered `spec` makes every review hunt for the field it cares about.
+
+## Usage
+
+```sh
+python scripts/yamlsorter/yamlsorter.py kubernetes             # sort in place
+python scripts/yamlsorter/yamlsorter.py kubernetes --check     # report only, exit 1 if unsorted
+python scripts/yamlsorter/yamlsorter.py kubernetes --audit     # list keys no template covers
+```
+
+Walking a directory picks up `helmrelease.yaml`, `kustomization.yaml` and `ks.yaml`
+(`--names` overrides). A file named explicitly is processed whatever it is called.
+Anything the templates do not cover — Secrets, HTTPRoutes, OCIRepositories — is
+skipped, not an error.
+
+lefthook runs it on staged manifests before `yamlfmt`.
+
+## Templates
+
+`scripts/config/<type>.yaml.tpl` holds one skeleton manifest per document type. Only its
+**keys** are read; the values are placeholders. Keys absent from a template keep their
+relative order and sort after the templated ones, so a template never has to be
+exhaustive — `--audit` lists what it is missing.
+
+| Template | Applies to |
+|---|---|
+| `flux-kustomization.yaml.tpl` | `kustomize.toolkit.fluxcd.io` Kustomizations (`ks.yaml`) |
+| `kustomization.yaml.tpl` | `kustomize.config.k8s.io` Kustomizations |
+| `component.yaml.tpl` | Kustomize Components |
+| `helmrelease-apptemplate.yaml.tpl` | HelmReleases whose `chartRef` is `app-template` |
+| `helmrelease.yaml.tpl` | every other HelmRelease |
+
+A HelmRelease resolves to `helmrelease-<chart>.yaml.tpl` (hyphens stripped) by `chartRef.name`,
+falling back to `helmrelease.yaml.tpl`. Adding `helmrelease-cilium.yaml.tpl` is enough to give
+Cilium its own ordering.
+
+A `"*"` key in a template stands for whatever name the manifest uses at that level, so
+one `containers."*"` entry orders every container in the repo.
+
+The `.tpl` suffix is load-bearing. A template is a well-formed Kustomization or
+HelmRelease, so under a plain `.yaml` name the repo-wide Flux scanners render it as a
+real resource — Konflate read `dependsOn: [{name: dependency}]` out of the placeholder
+and reported 95 dependency failures.
+
+## Tests
+
+```sh
+python -m pytest scripts/yamlsorter
+```

--- a/scripts/yamlsorter/tests/conftest.py
+++ b/scripts/yamlsorter/tests/conftest.py
@@ -1,0 +1,94 @@
+import sys
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+REPO_CONFIG = Path(__file__).resolve().parents[2] / "config"
+
+
+@pytest.fixture
+def yaml() -> YAML:
+    reader = YAML()
+    reader.preserve_quotes = True
+    reader.width = 4096
+    return reader
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """A minimal template set, enough to exercise ordering without the real repo one."""
+    directory = tmp_path / "config"
+    directory.mkdir()
+
+    (directory / "flux-kustomization.yaml.tpl").write_text(
+        "apiVersion: kustomize.toolkit.fluxcd.io/v1\n"
+        "kind: Kustomization\n"
+        "metadata:\n"
+        "  name: name\n"
+        "  namespace: namespace\n"
+        "spec:\n"
+        "  sourceRef:\n"
+        "    kind: kind\n"
+        "    name: name\n"
+        "    namespace: namespace\n"
+        "  path: path\n"
+        "  interval: interval\n"
+        "  dependsOn:\n"
+        "    - name: name\n"
+        "      namespace: namespace\n"
+        "  targetNamespace: targetNamespace\n"
+        "  components: []\n"
+        "  postBuild:\n"
+        "    substituteFrom: []\n"
+        "    substitute: {}\n"
+        "  prune: prune\n"
+        "  wait: wait\n",
+        encoding="utf-8",
+    )
+
+    (directory / "helmrelease.yaml.tpl").write_text(
+        "apiVersion: helm.toolkit.fluxcd.io/v2\n"
+        "kind: HelmRelease\n"
+        "metadata:\n"
+        "  name: name\n"
+        "spec:\n"
+        "  interval: interval\n"
+        "  chartRef:\n"
+        "    kind: kind\n"
+        "    name: name\n"
+        "  install: {}\n"
+        "  upgrade: {}\n"
+        "  values: {}\n",
+        encoding="utf-8",
+    )
+
+    (directory / "helmrelease-apptemplate.yaml.tpl").write_text(
+        "apiVersion: helm.toolkit.fluxcd.io/v2\n"
+        "kind: HelmRelease\n"
+        "metadata:\n"
+        "  name: name\n"
+        "spec:\n"
+        "  interval: interval\n"
+        "  chartRef:\n"
+        "    kind: kind\n"
+        "    name: name\n"
+        "  values:\n"
+        "    controllers:\n"
+        '      "*":\n'
+        "        annotations: {}\n"
+        "        containers:\n"
+        '          "*":\n'
+        "            image:\n"
+        "              repository: repository\n"
+        "              tag: tag\n"
+        "            env: {}\n"
+        "            envFrom: []\n"
+        "            securityContext: {}\n"
+        "            resources: {}\n",
+        encoding="utf-8",
+    )
+
+    return directory

--- a/scripts/yamlsorter/tests/fixtures.py
+++ b/scripts/yamlsorter/tests/fixtures.py
@@ -1,0 +1,29 @@
+"""Manifest bodies shared by the test modules."""
+
+KS = """\
+---
+# yaml-language-server: $schema=https://example.invalid/kustomization.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app
+spec:
+  targetNamespace: default
+  prune: true
+  path: ./kubernetes/apps/default/app
+  wait: true
+  sourceRef:
+    name: home-ops
+    kind: GitRepository
+  interval: 10m
+"""
+
+SECRET = """\
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app
+stringData:
+  KEY: value
+"""

--- a/scripts/yamlsorter/tests/test_behaviour.py
+++ b/scripts/yamlsorter/tests/test_behaviour.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+
+import pytest
+
+from fixtures import KS, SECRET
+from yamlsorter import FileTypeDetector, Outcome, SortingTool, main
+
+@pytest.mark.parametrize(
+    ("doc", "expected"),
+    [
+        ({"kind": "HelmRelease", "spec": {"chartRef": {"name": "app-template"}}}, "helmrelease-apptemplate"),
+        ({"kind": "HelmRelease", "spec": {"chart": {"spec": {"chart": "cilium"}}}}, "helmrelease-cilium"),
+        ({"kind": "HelmRelease", "spec": {}}, "helmrelease"),
+        (
+            {"kind": "Kustomization", "apiVersion": "kustomize.toolkit.fluxcd.io/v1"},
+            "flux-kustomization",
+        ),
+        (
+            {"kind": "Kustomization", "apiVersion": "kustomize.config.k8s.io/v1beta1"},
+            "kustomization",
+        ),
+        ({"kind": "Component", "apiVersion": "kustomize.config.k8s.io/v1alpha1"}, "component"),
+        ({"kind": "Secret"}, "generic"),
+        ({}, "generic"),
+    ],
+)
+def test_detect(doc: dict[str, object], expected: str):
+    assert FileTypeDetector.detect(doc) == expected
+
+
+def test_unsupported_document_is_skipped_not_failed(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "secret.sops.yaml"
+    _ = target.write_text(SECRET, encoding="utf-8")
+
+    result = SortingTool(config_dir).processor.process(target)
+
+    assert result.outcome is Outcome.SKIPPED
+    assert target.read_text(encoding="utf-8") == SECRET
+
+
+def test_unparseable_file_fails_without_writing(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text("apiVersion: [unclosed\n", encoding="utf-8")
+
+    result = SortingTool(config_dir).processor.process(target)
+
+    assert result.outcome is Outcome.FAILED
+    assert target.read_text(encoding="utf-8") == "apiVersion: [unclosed\n"
+
+
+def test_missing_config_dir_is_reported(tmp_path: Path):
+    tool = SortingTool(tmp_path / "absent")
+
+    assert tool.run([tmp_path], ["ks.yaml"], audit=False) == 2
+
+
+def test_empty_config_dir_is_reported(tmp_path: Path):
+    empty = tmp_path / "config"
+    empty.mkdir()
+
+    assert SortingTool(empty).run([tmp_path], ["ks.yaml"], audit=False) == 2
+
+
+def test_directory_walk_only_picks_up_named_files(tmp_path: Path, config_dir: Path):
+    (tmp_path / "app").mkdir()
+    _ = (tmp_path / "app" / "secret.sops.yaml").write_text(SECRET, encoding="utf-8")
+    _ = (tmp_path / "app" / "httproute.yaml").write_text(SECRET, encoding="utf-8")
+
+    tool = SortingTool(config_dir)
+    collected = list(tool._collect([tmp_path / "app"], ["ks.yaml", "helmrelease.yaml"]))
+
+    assert collected == []
+
+
+def test_explicit_file_argument_bypasses_the_name_filter(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "oddly-named.yaml"
+    _ = target.write_text(SECRET, encoding="utf-8")
+
+    collected = list(SortingTool(config_dir)._collect([target], ["ks.yaml"]))
+
+    assert collected == [target]
+
+
+def test_hidden_directories_are_not_walked(tmp_path: Path, config_dir: Path):
+    (tmp_path / ".git").mkdir()
+    _ = (tmp_path / ".git" / "ks.yaml").write_text(SECRET, encoding="utf-8")
+
+    collected = list(SortingTool(config_dir)._collect([tmp_path], ["ks.yaml"]))
+
+    assert collected == []
+
+
+def test_check_mode_reports_without_writing(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+
+    status = SortingTool(config_dir, dry_run=True).run([target], ["ks.yaml"], audit=False)
+
+    assert status == 1
+    assert target.read_text(encoding="utf-8") == KS
+
+
+def test_check_mode_passes_on_sorted_files(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+    _ = SortingTool(config_dir).run([target], ["ks.yaml"], audit=False)
+
+    assert SortingTool(config_dir, dry_run=True).run([target], ["ks.yaml"], audit=False) == 0
+
+
+def test_missing_template_type_is_skipped_rather_than_failing(tmp_path: Path, config_dir: Path):
+    (config_dir / "flux-kustomization.yaml.tpl").unlink()
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+
+    assert SortingTool(config_dir).processor.process(target).outcome is Outcome.SKIPPED
+
+
+def test_cli_exit_code_on_check(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+
+    assert main([str(target), "--config-dir", str(config_dir), "--check"]) == 1
+    assert main([str(target), "--config-dir", str(config_dir)]) == 0
+    assert main([str(target), "--config-dir", str(config_dir), "--check"]) == 0
+
+
+def test_comment_after_a_list_dash_blocks_the_rewrite(tmp_path: Path, config_dir: Path):
+    """ruamel reattaches such a comment to the previous entry, so refuse to rewrite."""
+    body = (
+        "---\n"
+        "apiVersion: kustomize.toolkit.fluxcd.io/v1\n"
+        "kind: Kustomization\n"
+        "metadata:\n"
+        "  name: app\n"
+        "spec:\n"
+        "  prune: true\n"
+        "  path: ./path\n"
+        "  sourceRef:\n"
+        "    kind: GitRepository\n"
+        "  dependsOn:\n"
+        "    - # first dependency\n"
+        "      name: one\n"
+        "    - # second dependency\n"
+        "      name: two\n"
+    )
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(body, encoding="utf-8")
+
+    result = SortingTool(config_dir).processor.process(target)
+
+    assert result.outcome is Outcome.SKIPPED
+    assert result.error is not None
+    assert "documents" in result.error
+    assert target.read_text(encoding="utf-8") == body
+
+
+def test_a_header_comment_does_not_block_the_rewrite(tmp_path: Path, config_dir: Path):
+    """Nothing reorders above the schema header, so it anchors to apiVersion either way."""
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+
+    result = SortingTool(config_dir).processor.process(target)
+
+    assert result.outcome is Outcome.CHANGED
+    assert target.read_text(encoding="utf-8").startswith(
+        "---\n# yaml-language-server: $schema=https://example.invalid/kustomization.json\n"
+        "apiVersion:"
+    )

--- a/scripts/yamlsorter/tests/test_ordering.py
+++ b/scripts/yamlsorter/tests/test_ordering.py
@@ -1,0 +1,174 @@
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from fixtures import KS
+from yamlsorter import Outcome, SortingTool, extract_key_order
+
+def sort_file(path: Path, config_dir: Path, **kwargs: object) -> Outcome:
+    tool = SortingTool(config_dir, **kwargs)  # type: ignore[arg-type]
+    return tool.processor.process(path).outcome
+
+
+def test_extract_key_order_flattens_nested_sections():
+    orders = extract_key_order({"spec": {"a": 1, "b": {"c": 2, "d": 3}}, "kind": "X"})
+
+    assert orders["root"] == ["spec", "kind"]
+    assert orders["spec"] == ["a", "b"]
+    assert orders["spec.b"] == ["c", "d"]
+
+
+def test_extract_key_order_merges_list_entry_keys():
+    orders = extract_key_order({"spec": {"deps": [{"a": 1}, {"b": 2, "a": 3}]}})
+
+    assert orders["spec.deps"] == ["a", "b"]
+
+
+def test_spec_keys_follow_template(tmp_path: Path, config_dir: Path, yaml: YAML):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+
+    assert sort_file(target, config_dir) is Outcome.CHANGED
+
+    doc = yaml.load(target.read_text(encoding="utf-8"))
+    assert list(doc["spec"]) == [
+        "sourceRef",
+        "path",
+        "interval",
+        "targetNamespace",
+        "prune",
+        "wait",
+    ]
+    assert list(doc["spec"]["sourceRef"]) == ["kind", "name"]
+
+
+def test_schema_comment_and_document_start_survive(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+
+    _ = sort_file(target, config_dir)
+    text = target.read_text(encoding="utf-8")
+
+    assert text.startswith("---\n# yaml-language-server: $schema=")
+
+
+def test_already_sorted_file_is_untouched(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+    _ = sort_file(target, config_dir)
+    once = target.read_text(encoding="utf-8")
+
+    assert sort_file(target, config_dir) is Outcome.UNCHANGED
+    assert target.read_text(encoding="utf-8") == once
+
+
+def test_untemplated_keys_keep_their_order_after_templated_ones(
+    tmp_path: Path, config_dir: Path, yaml: YAML
+):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(
+        KS.replace("  interval: 10m\n", "  interval: 10m\n  zebra: 1\n  alpha: 2\n"),
+        encoding="utf-8",
+    )
+
+    _ = sort_file(target, config_dir)
+
+    doc = yaml.load(target.read_text(encoding="utf-8"))
+    assert list(doc["spec"])[-2:] == ["zebra", "alpha"]
+
+
+def test_wildcard_template_orders_container_keys(
+    tmp_path: Path, config_dir: Path, yaml: YAML
+):
+    target = tmp_path / "helmrelease.yaml"
+    _ = target.write_text(
+        "---\n"
+        "apiVersion: helm.toolkit.fluxcd.io/v2\n"
+        "kind: HelmRelease\n"
+        "metadata:\n"
+        "  name: app\n"
+        "spec:\n"
+        "  chartRef:\n"
+        "    kind: OCIRepository\n"
+        "    name: app-template\n"
+        "  interval: 30m\n"
+        "  values:\n"
+        "    controllers:\n"
+        "      app:\n"
+        "        containers:\n"
+        "          app:\n"
+        "            resources: {}\n"
+        "            securityContext: {}\n"
+        "            env:\n"
+        "              TZ: Europe/Paris\n"
+        "            image:\n"
+        "              tag: v1\n"
+        "              repository: repo\n",
+        encoding="utf-8",
+    )
+
+    assert sort_file(target, config_dir) is Outcome.CHANGED
+
+    doc = yaml.load(target.read_text(encoding="utf-8"))
+    container = doc["spec"]["values"]["controllers"]["app"]["containers"]["app"]
+    assert list(container) == ["image", "env", "securityContext", "resources"]
+    assert list(container["image"]) == ["repository", "tag"]
+
+
+def test_anchors_and_aliases_survive(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "helmrelease.yaml"
+    _ = target.write_text(
+        "---\n"
+        "apiVersion: helm.toolkit.fluxcd.io/v2\n"
+        "kind: HelmRelease\n"
+        "metadata:\n"
+        "  name: &app app\n"
+        "spec:\n"
+        "  values:\n"
+        "    controllers:\n"
+        "      *app: {}\n"
+        "  interval: 30m\n"
+        "  chartRef:\n"
+        "    kind: OCIRepository\n"
+        "    name: other\n",
+        encoding="utf-8",
+    )
+
+    _ = sort_file(target, config_dir)
+    text = target.read_text(encoding="utf-8")
+
+    assert "&app" in text
+    assert "*app" in text
+
+
+def test_quoted_scalars_keep_their_quotes(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(
+        KS.replace("  interval: 10m\n", '  interval: 10m\n  quoted: "1"\n'),
+        encoding="utf-8",
+    )
+
+    _ = sort_file(target, config_dir)
+
+    assert 'quoted: "1"' in target.read_text(encoding="utf-8")
+
+
+def test_file_permissions_are_preserved(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS, encoding="utf-8")
+    target.chmod(0o640)
+
+    _ = sort_file(target, config_dir)
+
+    assert target.stat().st_mode & 0o777 == 0o640
+
+
+def test_multi_document_file_sorts_every_document(tmp_path: Path, config_dir: Path):
+    target = tmp_path / "ks.yaml"
+    _ = target.write_text(KS + KS.replace("name: app", "name: other"), encoding="utf-8")
+
+    assert sort_file(target, config_dir) is Outcome.CHANGED
+
+    text = target.read_text(encoding="utf-8")
+    assert text.count("---") == 2
+    assert text.count("sourceRef") == 2

--- a/scripts/yamlsorter/yamlsorter.py
+++ b/scripts/yamlsorter/yamlsorter.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Reorder keys in Flux manifests to match per-type templates.
+
+Key order is not semantic to Kubernetes, but a stable order makes diffs readable
+and reviews mechanical. The desired order is declared by example: each file in the
+config directory is a manifest skeleton whose *keys* define the order for its type.
+Values there are ignored.
+
+Keys absent from a template keep their relative order and sort after the templated
+ones, so a template never has to be exhaustive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Final, final
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+type YAMLValue = str | int | float | bool | list["YAMLValue"] | dict[str, "YAMLValue"] | None
+
+GENERIC: Final = "generic"
+WILDCARD: Final = "*"
+ROOT_SECTION: Final = "root"
+PATH_SEP: Final = "."
+# Templates are skeletons, not manifests: the suffix keeps repo-wide Flux scanners
+# (Konflate, flux-local) from rendering the placeholder values as real resources.
+TEMPLATE_SUFFIX: Final = ".yaml.tpl"
+
+log = logging.getLogger("yamlsorter")
+
+
+class Outcome(Enum):
+    """What happened to one file."""
+
+    CHANGED = "changed"
+    UNCHANGED = "unchanged"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class Result:
+    path: Path
+    outcome: Outcome
+    file_type: str = GENERIC
+    error: str | None = None
+
+
+@final
+@dataclass(slots=True)
+class Stats:
+    total: int = 0
+    changed: int = 0
+    unchanged: int = 0
+    skipped: int = 0
+    failed: int = 0
+    missing_keys: dict[str, set[str]] = field(default_factory=dict)
+
+    def record(self, result: Result) -> None:
+        self.total += 1
+        match result.outcome:
+            case Outcome.CHANGED:
+                self.changed += 1
+            case Outcome.UNCHANGED:
+                self.unchanged += 1
+            case Outcome.SKIPPED:
+                self.skipped += 1
+            case Outcome.FAILED:
+                self.failed += 1
+
+
+class YAMLSorterError(Exception):
+    """Base class for errors this tool raises deliberately."""
+
+
+class ConfigError(YAMLSorterError):
+    """A template is missing or unusable."""
+
+
+class ParseError(YAMLSorterError):
+    """A manifest could not be parsed."""
+
+
+def _yaml_reader() -> YAML:
+    """Round-trip parser. Comments, anchors and quoting survive a load/dump cycle."""
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.map_indent = 2
+    yaml.sequence_indent = 4
+    yaml.sequence_dash_offset = 2
+    yaml.width = 4096
+    yaml.default_flow_style = None
+    return yaml
+
+
+def extract_key_order(template: dict[str, YAMLValue]) -> dict[str, list[str]]:
+    """Flatten a template manifest into {dotted.section: [keys in order]}."""
+    orders: dict[str, list[str]] = {}
+
+    def walk(node: YAMLValue, path: list[str]) -> None:
+        if not isinstance(node, dict):
+            return
+
+        orders[PATH_SEP.join(path) if path else ROOT_SECTION] = list(node.keys())
+
+        for key, value in node.items():
+            child = [*path, key]
+            if isinstance(value, dict):
+                walk(value, child)
+            elif isinstance(value, list):
+                # A list in a template describes the shape of its entries, not their
+                # count: merge every entry's keys into one order for that section.
+                entries = [item for item in value if isinstance(item, dict)]
+                merged: list[str] = []
+                for entry in entries:
+                    merged.extend(k for k in entry if k not in merged)
+                    walk(entry, child)
+                if merged:
+                    orders[PATH_SEP.join(child)] = merged
+
+    walk(template, [])
+    return orders
+
+
+@final
+class FileTypeDetector:
+    """Names the template a document should be sorted against."""
+
+    KIND_TYPES: Final[dict[str, str]] = {"Component": "component"}
+
+    @classmethod
+    def detect(cls, data: dict[str, YAMLValue]) -> str:
+        kind = data.get("kind")
+        api_version = data.get("apiVersion")
+
+        if kind == "HelmRelease":
+            chart = cls._chart_name(data)
+            return f"helmrelease-{chart}" if chart else "helmrelease"
+
+        if kind == "Kustomization":
+            is_flux = isinstance(api_version, str) and "kustomize.toolkit.fluxcd.io" in api_version
+            return "flux-kustomization" if is_flux else "kustomization"
+
+        if isinstance(kind, str) and kind in cls.KIND_TYPES:
+            return cls.KIND_TYPES[kind]
+
+        return GENERIC
+
+    @staticmethod
+    def _chart_name(data: dict[str, YAMLValue]) -> str | None:
+        """Chart backing a HelmRelease, via chartRef (this repo) or inline chart."""
+        spec = data.get("spec")
+        if not isinstance(spec, dict):
+            return None
+
+        chart_ref = spec.get("chartRef")
+        if isinstance(chart_ref, dict):
+            name = chart_ref.get("name")
+            if isinstance(name, str):
+                return name.replace("-", "")
+
+        chart = spec.get("chart")
+        if isinstance(chart, dict):
+            chart_spec = chart.get("spec")
+            if isinstance(chart_spec, dict):
+                name = chart_spec.get("chart")
+                if isinstance(name, str):
+                    return name.replace("-", "")
+
+        return None
+
+
+@final
+class ConfigManager:
+    """Loads templates, falling back from chart-specific to generic HelmRelease."""
+
+    def __init__(self, config_dir: Path) -> None:
+        self.config_dir = config_dir
+        self._orders: dict[str, dict[str, list[str]]] = {}
+        self._yaml = YAML(typ="safe")
+
+    def validate(self) -> None:
+        if not self.config_dir.is_dir():
+            raise ConfigError(f"config directory not found: {self.config_dir}")
+        if not any(self.config_dir.glob(f"*{TEMPLATE_SUFFIX}")):
+            raise ConfigError(f"no templates in {self.config_dir}")
+
+    def has_template(self, file_type: str) -> bool:
+        return self._resolve(file_type) is not None
+
+    def load(self, file_type: str) -> dict[str, list[str]]:
+        if file_type in self._orders:
+            return self._orders[file_type]
+
+        path = self._resolve(file_type)
+        if path is None:
+            raise ConfigError(f"no template for type {file_type!r} in {self.config_dir}")
+
+        try:
+            with path.open(encoding="utf-8") as handle:
+                template = self._yaml.load(handle)
+        except Exception as exc:
+            raise ConfigError(f"failed to read template {path}: {exc}") from exc
+
+        if not isinstance(template, dict):
+            raise ConfigError(f"template {path} is not a mapping")
+
+        orders = extract_key_order(template)
+        self._orders[file_type] = orders
+        return orders
+
+    def _resolve(self, file_type: str) -> Path | None:
+        exact = self.config_dir / f"{file_type}{TEMPLATE_SUFFIX}"
+        if exact.is_file():
+            return exact
+        if file_type.startswith("helmrelease-"):
+            fallback = self.config_dir / f"helmrelease{TEMPLATE_SUFFIX}"
+            if fallback.is_file():
+                return fallback
+        return None
+
+
+@final
+class KeySorter:
+    """Applies a template's key order to a parsed document, in place."""
+
+    def __init__(self, config: ConfigManager) -> None:
+        self.config = config
+
+    def sort_document(self, doc: CommentedMap, orders: dict[str, list[str]]) -> CommentedMap:
+        return self._sort_node(doc, orders, [])
+
+    def _sort_node(
+        self, node: dict[str, YAMLValue], orders: dict[str, list[str]], path: list[str]
+    ) -> CommentedMap:
+        ordered = self._reorder(node, self._order_for(orders, path))
+
+        for key, value in ordered.items():
+            child = [*path, key]
+            if isinstance(value, dict):
+                ordered[key] = self._sort_node(value, orders, child)
+            elif isinstance(value, list):
+                for index, item in enumerate(value):
+                    if isinstance(item, dict):
+                        value[index] = self._sort_node(item, orders, child)
+
+        return ordered
+
+    @staticmethod
+    def _reorder(node: dict[str, YAMLValue], order: list[str]) -> CommentedMap:
+        """Rewrite a mapping in `order`, untemplated keys keeping their order after.
+
+        A CommentedMap is refilled in place: comments, anchors and flow style hang off
+        the container, so replacing it would drop them.
+        """
+        if not order:
+            return node if isinstance(node, CommentedMap) else CommentedMap(node)
+
+        templated = [key for key in order if key in node]
+        if not templated:
+            return node if isinstance(node, CommentedMap) else CommentedMap(node)
+
+        rest = [key for key in node if key not in order]
+        target = [*templated, *rest]
+
+        if list(node.keys()) == target:
+            return node if isinstance(node, CommentedMap) else CommentedMap(node)
+
+        if not isinstance(node, CommentedMap):
+            return CommentedMap((key, node[key]) for key in target)
+
+        values = dict(node)
+        node.clear()
+        for key in target:
+            node[key] = values[key]
+        return node
+
+    @staticmethod
+    def _order_for(orders: dict[str, list[str]], path: list[str]) -> list[str]:
+        if not path:
+            return orders.get(ROOT_SECTION, [])
+
+        section = PATH_SEP.join(path)
+        if section in orders:
+            return orders[section]
+
+        # `controllers.*.containers.*` style templates: a literal path component is
+        # matched exactly, `*` matches whatever the manifest called that level.
+        for candidate, order in orders.items():
+            parts = candidate.split(PATH_SEP)
+            if len(parts) != len(path):
+                continue
+            if all(p == WILDCARD or p == actual for p, actual in zip(parts, path, strict=True)):
+                return order
+
+        return []
+
+
+def _comment_anchors(text: str) -> list[tuple[str, str]]:
+    """Pair every comment with the first line of content beneath it."""
+    lines = [line.strip() for line in text.splitlines()]
+    anchors: list[tuple[str, str]] = []
+
+    for index, line in enumerate(lines):
+        if not line.startswith("#"):
+            continue
+        following = next(
+            (later for later in lines[index + 1 :] if later and not later.startswith("#")),
+            "",
+        )
+        anchors.append((line, following))
+
+    return anchors
+
+
+def _detached_comments(original: str, rendered: str) -> str | None:
+    """Name a comment the round-trip re-anchored, if any.
+
+    ruamel cannot faithfully re-emit a comment that sits after a list dash
+    (`- # note`): it reattaches to the preceding entry, so the note ends up
+    describing the wrong item. Rewriting such a file would silently mislead.
+    """
+    before = _comment_anchors(original)
+    after = _comment_anchors(rendered)
+
+    if len(before) != len(after):
+        return "a comment"
+
+    for (comment, was), (_, now) in zip(before, after, strict=True):
+        if was != now:
+            return repr(comment)
+
+    return None
+
+
+@final
+class FileProcessor:
+    """Parses, sorts and rewrites one file."""
+
+    def __init__(self, sorter: KeySorter, config: ConfigManager, dry_run: bool) -> None:
+        self.sorter = sorter
+        self.config = config
+        self.dry_run = dry_run
+        self._yaml = _yaml_reader()
+
+    def process(self, path: Path) -> Result:
+        try:
+            original = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return Result(path, Outcome.FAILED, error=str(exc))
+
+        try:
+            docs = list(self._yaml.load_all(original))
+        except Exception as exc:
+            return Result(path, Outcome.FAILED, error=f"unparseable: {exc}")
+
+        typed = [
+            (doc, FileTypeDetector.detect(doc)) for doc in docs if isinstance(doc, CommentedMap)
+        ]
+        sortable = [
+            (doc, kind)
+            for doc, kind in typed
+            if kind != GENERIC and self.config.has_template(kind)
+        ]
+        if not sortable:
+            return Result(path, Outcome.SKIPPED)
+
+        file_type = sortable[0][1]
+        try:
+            for doc, kind in sortable:
+                self.sorter.sort_document(doc, self.config.load(kind))
+        except (ConfigError, ParseError) as exc:
+            return Result(path, Outcome.FAILED, file_type, str(exc))
+
+        rendered = self._render(docs, explicit_start=original.lstrip().startswith("---"))
+        if rendered.strip() == original.strip():
+            return Result(path, Outcome.UNCHANGED, file_type)
+
+        moved = _detached_comments(original, rendered)
+        if moved:
+            return Result(
+                path,
+                Outcome.SKIPPED,
+                file_type,
+                f"round-trip would move {moved} away from what it documents",
+            )
+
+        if not self.dry_run:
+            try:
+                self._write(path, rendered)
+            except OSError as exc:
+                return Result(path, Outcome.FAILED, file_type, str(exc))
+
+        return Result(path, Outcome.CHANGED, file_type)
+
+    def _render(self, docs: list[YAMLValue], explicit_start: bool) -> str:
+        buffer = io.StringIO()
+        for index, doc in enumerate(docs):
+            if index > 0 or explicit_start:
+                _ = buffer.write("---\n")
+            self._yaml.dump(doc, buffer)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _write(path: Path, content: str) -> None:
+        """Replace the file atomically, keeping its permissions."""
+        mode = path.stat().st_mode
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", dir=path.parent, delete=False, encoding="utf-8", suffix=".yamlsorter"
+        )
+        try:
+            with tmp:
+                _ = tmp.write(content)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.chmod(tmp.name, mode & 0o7777)
+            shutil.move(tmp.name, path)
+        except Exception:
+            Path(tmp.name).unlink(missing_ok=True)
+            raise
+
+
+@final
+class MissingKeyAuditor:
+    """Reports manifest keys no template mentions, so templates can be grown."""
+
+    def __init__(self, config: ConfigManager, substitution_markers: set[str]) -> None:
+        self.config = config
+        self.markers = substitution_markers
+
+    def audit(self, docs: Iterable[CommentedMap], stats: Stats) -> None:
+        for doc in docs:
+            file_type = FileTypeDetector.detect(doc)
+            if file_type == GENERIC or not self.config.has_template(file_type):
+                continue
+
+            try:
+                orders = self.config.load(file_type)
+            except ConfigError:
+                continue
+
+            known = {key for keys in orders.values() for key in keys if key != WILDCARD}
+            wildcard_sections = {
+                section for section, keys in orders.items() if WILDCARD in keys
+            }
+
+            # A chart-specific template covers spec.values; the generic one does not,
+            # so auditing it there would flag every chart option as missing.
+            skip_values = not (self.config.config_dir / f"{file_type}{TEMPLATE_SUFFIX}").is_file()
+
+            used = self._keys(doc, [], wildcard_sections, skip_values)
+            missing = used - known
+            if missing:
+                stats.missing_keys.setdefault(file_type, set()).update(missing)
+
+    # Keys inside these are user-chosen names, not schema, so they are never "missing".
+    OPAQUE_MAPS: Final[frozenset[str]] = frozenset(
+        {"labels", "annotations", "matchLabels", "nodeSelector", "data", "stringData", "env"}
+    )
+
+    def _keys(
+        self,
+        node: dict[str, YAMLValue],
+        path: list[str],
+        wildcard_sections: set[str],
+        skip_values: bool,
+    ) -> set[str]:
+        found: set[str] = set()
+
+        for key, value in node.items():
+            child = [*path, key]
+
+            if skip_values and child[:2] == ["spec", "values"]:
+                continue
+            if self._is_substitution(key):
+                continue
+            if self._under_wildcard(child, wildcard_sections):
+                continue
+
+            found.add(key)
+
+            if key in self.OPAQUE_MAPS:
+                continue
+
+            if isinstance(value, dict):
+                found |= self._keys(value, child, wildcard_sections, skip_values)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        found |= self._keys(item, child, wildcard_sections, skip_values)
+
+        return found
+
+    def _is_substitution(self, key: str) -> bool:
+        if "ALL_CAPS" in self.markers and key.isupper() and key.replace("_", "").isalpha():
+            return True
+        return any(marker != "ALL_CAPS" and marker in key for marker in self.markers)
+
+    @staticmethod
+    def _under_wildcard(path: list[str], wildcard_sections: set[str]) -> bool:
+        """True for names the template stands in for with `*` (app names, env vars)."""
+        prefix = PATH_SEP.join(path[:-1])
+        return any(
+            prefix == section or prefix.startswith(f"{section}{PATH_SEP}")
+            for section in wildcard_sections
+        )
+
+
+@final
+class SortingTool:
+    def __init__(
+        self,
+        config_dir: Path,
+        *,
+        dry_run: bool = False,
+        substitution_markers: set[str] | None = None,
+    ) -> None:
+        self.config = ConfigManager(config_dir)
+        self.sorter = KeySorter(self.config)
+        self.processor = FileProcessor(self.sorter, self.config, dry_run)
+        self.auditor = MissingKeyAuditor(
+            self.config, substitution_markers or {"ALL_CAPS"}
+        )
+        self.dry_run = dry_run
+
+    def run(self, paths: list[Path], names: list[str], *, audit: bool) -> int:
+        try:
+            self.config.validate()
+        except ConfigError as exc:
+            log.error("%s", exc)
+            return 2
+
+        files = sorted(set(self._collect(paths, names)))
+        if not files:
+            log.warning("no matching files found")
+            return 0
+
+        stats = Stats()
+        for path in files:
+            result = self.processor.process(path)
+            stats.record(result)
+
+            match result.outcome:
+                case Outcome.CHANGED:
+                    log.info("%s %s (%s)", "would sort" if self.dry_run else "sorted", path, result.file_type)
+                case Outcome.FAILED:
+                    log.error("%s: %s", path, result.error)
+                case Outcome.SKIPPED if result.error:
+                    log.warning("skipped %s: %s", path, result.error)
+                case Outcome.SKIPPED:
+                    log.debug("skipped %s", path)
+                case Outcome.UNCHANGED:
+                    log.debug("unchanged %s", path)
+
+            if audit and result.outcome is not Outcome.FAILED:
+                self._audit(path, stats)
+
+        self._report(stats)
+        if stats.failed:
+            return 2
+        # In check mode an unsorted file is the finding, so it has to fail the run.
+        return 1 if self.dry_run and stats.changed else 0
+
+    def _audit(self, path: Path, stats: Stats) -> None:
+        try:
+            docs = self.processor._yaml.load_all(path.read_text(encoding="utf-8"))
+            self.auditor.audit((d for d in docs if isinstance(d, CommentedMap)), stats)
+        except Exception:  # auditing is advisory; never fail a run over it
+            log.debug("audit failed for %s", path, exc_info=True)
+
+    @staticmethod
+    def _collect(paths: list[Path], names: list[str]) -> Iterator[Path]:
+        """Yield the files to sort. Explicit file arguments bypass the name filter."""
+        wanted = set(names)
+        for path in paths:
+            if path.is_file():
+                yield path
+            elif path.is_dir():
+                for root, dirs, filenames in os.walk(path):
+                    dirs[:] = [d for d in dirs if not d.startswith(".")]
+                    yield from (
+                        Path(root) / name for name in filenames if name in wanted
+                    )
+            else:
+                log.warning("no such path: %s", path)
+
+    def _report(self, stats: Stats) -> None:
+        log.info(
+            "%d files: %d %s, %d unchanged, %d skipped, %d failed",
+            stats.total,
+            stats.changed,
+            "to sort" if self.dry_run else "sorted",
+            stats.unchanged,
+            stats.skipped,
+            stats.failed,
+        )
+
+        for file_type, keys in sorted(stats.missing_keys.items()):
+            log.info("keys absent from %s%s: %s", file_type, TEMPLATE_SUFFIX, ", ".join(sorted(keys)))
+
+
+DEFAULT_NAMES: Final = ["helmrelease.yaml", "kustomization.yaml", "ks.yaml"]
+DEFAULT_MARKERS: Final = ["ALL_CAPS", "kustomize.toolkit.fluxcd.io/substitute"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="yamlsorter",
+        description="Reorder keys in Flux manifests to match per-type templates.",
+    )
+    _ = parser.add_argument("paths", type=Path, nargs="+", help="files or directories to sort")
+    _ = parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=Path("scripts/config"),
+        help="directory of template manifests (default: %(default)s)",
+    )
+    _ = parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report what would change without writing, exit 1 if anything would",
+    )
+    _ = parser.add_argument("--dry-run", action="store_true", help="alias for --check")
+    _ = parser.add_argument(
+        "--names",
+        nargs="+",
+        default=DEFAULT_NAMES,
+        metavar="NAME",
+        help="filenames to pick up when walking directories (default: %(default)s)",
+    )
+    _ = parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="also list manifest keys no template mentions",
+    )
+    _ = parser.add_argument("--verbose", "-v", action="store_true", help="log skipped files too")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+        stream=sys.stderr,
+    )
+
+    tool = SortingTool(
+        config_dir=args.config_dir,
+        dry_run=args.check or args.dry_run,
+        substitution_markers=set(DEFAULT_MARKERS),
+    )
+    return tool.run(args.paths, args.names, audit=args.audit)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Recovers `yamlsorter` from the abandoned `prettier` branch, where it sat unmerged for a year, and puts it to work. The prettier half of that branch is not carried over — the repo formats with yamlfmt now.

Key order means nothing to Kubernetes, so it drifts freely, and every review then has to hunt for the field it cares about. This pins an order per document type, declared by example in `scripts/config/`.

## Commits

1. **`feat(scripts): add yamlsorter`** — the tool, its templates, and 32 tests
2. **`feat(lefthook): sort manifest keys on commit`** — runs on staged manifests, before yamlfmt
3. **`style: sort manifest keys`** — the migration, 138 files

## What was broken in the original

Four defects made it unusable as it stood:

- **Chart detection was dead code.** It read `spec.chart.spec.chart`, which this repo stopped using when it moved to `chartRef`. `helmrelease-apptemplate.yaml` therefore never matched a single file, and every app-template HelmRelease silently fell back to the generic template.
- **`--file-types` was ignored while walking.** Every `.yaml` in the tree got parsed, and each unsupported one counted as an error — so the run always exited 1. Unusable as a hook.
- **Rewrites clobbered file modes.** Output went through a `NamedTemporaryFile` and inherited its `0600`, which would have stripped the mode off all 138 files.
- **Wildcard matching never fired.** Section paths were joined with `_` while the templates key off `.`, so no `"*"` template ever matched during the missing-key audit.

## One limit enforced rather than fixed

ruamel cannot faithfully re-emit a comment that sits at the top of a mapping it then reorders, or after a list dash (`- # note`) — the note reattaches to the neighbouring entry and ends up describing the wrong thing. Rather than ship that, the tool detects it and refuses the file.

Three files are refused on those grounds (`coredns`, `flux-instance`, `flux/cluster`), plus `components/replacements/ks.yaml` which has no document a template covers. They can be sorted by hand later or left alone.

## Templates

Ordering is the one from the `prettier` branch, kept as-is. Only stale content was refreshed:

- `chartRef`/OCIRepository instead of `chart:` + `HelmRepository`, which CLAUDE.md now bans
- schema URLs moved to `k8s-schemas.home-operations.com`
- Gateway API `route` instead of `ingress`
- the keys `--audit` reported missing: `deletionPolicy`, `patches.target.group`, `terminationGracePeriodSeconds`

Worth knowing: onedr0p sorts these keys **alphabetically**. This keeps semantic grouping instead — `sourceRef`/`path` together, the timing knobs together, `prune`/`wait`/`force` together — on the grounds that alphabetical splits related keys apart for no gain.

CLAUDE.md's `ks.yaml` example documents a third order again, and now disagrees with the template. Not touched here — one concern per commit — but it should be reconciled, and the template is the half that gets enforced.

## Verification

- 32 tests pass, covering ordering, wildcards, anchors/aliases, quoting, multi-doc files, file modes, and the comment guard
- all 138 changed files parse to the **same document** they did before — checked by comparing `safe_load_all` output per file
- `kubeconform.sh` exits 0, 461 resources valid, unchanged from before
- comment line count identical before and after (172 → 172); every schema header intact
- no file mode changes
- re-running the sorter is a no-op, so the hook won't fight the tree
- `lefthook run pre-commit` verified end to end: unsorted file staged → sorted back to zero diff, in the right order relative to yamlfmt
